### PR TITLE
Replace DB_ATTRTYPE_* defines with class constants

### DIFF
--- a/src/main/php/rdbms/DBTableAttribute.class.php
+++ b/src/main/php/rdbms/DBTableAttribute.class.php
@@ -1,36 +1,5 @@
 <?php namespace rdbms;
 
-define('DB_ATTRTYPE_BINARY',         0x0000);             
-define('DB_ATTRTYPE_BIT',            0x0001);               
-define('DB_ATTRTYPE_CHAR',           0x0002);              
-define('DB_ATTRTYPE_DATETIME',       0x0003);            
-define('DB_ATTRTYPE_DATETIMN',       0x0004);            
-define('DB_ATTRTYPE_DECIMAL',        0x0005);             
-define('DB_ATTRTYPE_DECIMALN',       0x0006);            
-define('DB_ATTRTYPE_FLOAT',          0x0007);             
-define('DB_ATTRTYPE_FLOATN',         0x0008);            
-define('DB_ATTRTYPE_IMAGE',          0x0009);             
-define('DB_ATTRTYPE_INT',            0x000A);               
-define('DB_ATTRTYPE_INTN',           0x000B);              
-define('DB_ATTRTYPE_MONEY',          0x000C);             
-define('DB_ATTRTYPE_MONEYN',         0x000D);            
-define('DB_ATTRTYPE_NCHAR',          0x000E);             
-define('DB_ATTRTYPE_NUMERIC',        0x000F);             
-define('DB_ATTRTYPE_NUMERICN',       0x0010);            
-define('DB_ATTRTYPE_NVARCHAR',       0x0011);            
-define('DB_ATTRTYPE_REAL',           0x0012);              
-define('DB_ATTRTYPE_SMALLDATETIME',  0x0013);         
-define('DB_ATTRTYPE_SMALLINT',       0x0014);         
-define('DB_ATTRTYPE_SMALLMONEY',     0x0015);       
-define('DB_ATTRTYPE_SYSNAME',        0x0016);          
-define('DB_ATTRTYPE_TEXT',           0x0017);           
-define('DB_ATTRTYPE_TIMESTAMP',      0x0018);        
-define('DB_ATTRTYPE_TINYINT',        0x0019);          
-define('DB_ATTRTYPE_VARBINARY',      0x001A);        
-define('DB_ATTRTYPE_VARCHAR',        0x001B);          
-define('DB_ATTRTYPE_ENUM',           0x001C);          
-define('DB_ATTRTYPE_DATE',           0x001D);
-
 /**
  * Represents a table's attribute
  *
@@ -45,7 +14,39 @@ class DBTableAttribute extends \lang\Object {
     $length=      0,
     $precision=   0,
     $scale=       0;
-    
+
+  const
+    DB_ATTRTYPE_BINARY=          0x0000,
+    DB_ATTRTYPE_BIT=             0x0001,
+    DB_ATTRTYPE_CHAR=            0x0002,
+    DB_ATTRTYPE_DATETIME=        0x0003,
+    DB_ATTRTYPE_DATETIMN=        0x0004,
+    DB_ATTRTYPE_DECIMAL=         0x0005,
+    DB_ATTRTYPE_DECIMALN=        0x0006,
+    DB_ATTRTYPE_FLOAT=           0x0007,
+    DB_ATTRTYPE_FLOATN=          0x0008,
+    DB_ATTRTYPE_IMAGE=           0x0009,
+    DB_ATTRTYPE_INT=             0x000A,
+    DB_ATTRTYPE_INTN=            0x000B,
+    DB_ATTRTYPE_MONEY=           0x000C,
+    DB_ATTRTYPE_MONEYN=          0x000D,
+    DB_ATTRTYPE_NCHAR=           0x000E,
+    DB_ATTRTYPE_NUMERIC=         0x000F,
+    DB_ATTRTYPE_NUMERICN=        0x0010,
+    DB_ATTRTYPE_NVARCHAR=        0x0011,
+    DB_ATTRTYPE_REAL=            0x0012,
+    DB_ATTRTYPE_SMALLDATETIME=   0x0013,
+    DB_ATTRTYPE_SMALLINT=        0x0014,
+    DB_ATTRTYPE_SMALLMONEY=      0x0015,
+    DB_ATTRTYPE_SYSNAME=         0x0016,
+    DB_ATTRTYPE_TEXT=            0x0017,
+    DB_ATTRTYPE_TIMESTAMP=       0x0018,
+    DB_ATTRTYPE_TINYINT=         0x0019,
+    DB_ATTRTYPE_VARBINARY=       0x001A,
+    DB_ATTRTYPE_VARCHAR=         0x001B,
+    DB_ATTRTYPE_ENUM=            0x001C,
+    DB_ATTRTYPE_DATE=            0x001D;
+
   /**
    * Constructor
    *
@@ -178,48 +179,48 @@ class DBTableAttribute extends \lang\Object {
    */
   public function typeName() {
     switch ($this->type) {   
-      case DB_ATTRTYPE_BIT:
+      case self::DB_ATTRTYPE_BIT:
         return 'bool';
         
-      case DB_ATTRTYPE_DATETIME:
-      case DB_ATTRTYPE_DATETIMN:  
-      case DB_ATTRTYPE_TIMESTAMP:
-      case DB_ATTRTYPE_SMALLDATETIME:
-      case DB_ATTRTYPE_DATE:
+      case self::DB_ATTRTYPE_DATETIME:
+      case self::DB_ATTRTYPE_DATETIMN:
+      case self::DB_ATTRTYPE_TIMESTAMP:
+      case self::DB_ATTRTYPE_SMALLDATETIME:
+      case self::DB_ATTRTYPE_DATE:
         return 'util.Date';
         
-      case DB_ATTRTYPE_BINARY:
-      case DB_ATTRTYPE_CHAR:
-      case DB_ATTRTYPE_IMAGE:
-      case DB_ATTRTYPE_NCHAR:  
-      case DB_ATTRTYPE_NVARCHAR:
-      case DB_ATTRTYPE_TEXT:
-      case DB_ATTRTYPE_VARBINARY:
-      case DB_ATTRTYPE_VARCHAR:
-      case DB_ATTRTYPE_ENUM:
+      case self::DB_ATTRTYPE_BINARY:
+      case self::DB_ATTRTYPE_CHAR:
+      case self::DB_ATTRTYPE_IMAGE:
+      case self::DB_ATTRTYPE_NCHAR:
+      case self::DB_ATTRTYPE_NVARCHAR:
+      case self::DB_ATTRTYPE_TEXT:
+      case self::DB_ATTRTYPE_VARBINARY:
+      case self::DB_ATTRTYPE_VARCHAR:
+      case self::DB_ATTRTYPE_ENUM:
         return 'string';
         
-      case DB_ATTRTYPE_DECIMAL:
-      case DB_ATTRTYPE_DECIMALN:
-      case DB_ATTRTYPE_NUMERIC:  
-      case DB_ATTRTYPE_NUMERICN:
+      case self::DB_ATTRTYPE_DECIMAL:
+      case self::DB_ATTRTYPE_DECIMALN:
+      case self::DB_ATTRTYPE_NUMERIC:
+      case self::DB_ATTRTYPE_NUMERICN:
         return $this->scale == 0 ? 'int' : 'float';
         
-      case DB_ATTRTYPE_INT:
-      case DB_ATTRTYPE_INTN:
-      case DB_ATTRTYPE_TINYINT:
-      case DB_ATTRTYPE_SMALLINT:
+      case self::DB_ATTRTYPE_INT:
+      case self::DB_ATTRTYPE_INTN:
+      case self::DB_ATTRTYPE_TINYINT:
+      case self::DB_ATTRTYPE_SMALLINT:
         return 'int';
         
-      case DB_ATTRTYPE_FLOAT:
-      case DB_ATTRTYPE_FLOATN:
-      case DB_ATTRTYPE_MONEY:
-      case DB_ATTRTYPE_MONEYN:
-      case DB_ATTRTYPE_SMALLMONEY:
-      case DB_ATTRTYPE_REAL:
+      case self::DB_ATTRTYPE_FLOAT:
+      case self::DB_ATTRTYPE_FLOATN:
+      case self::DB_ATTRTYPE_MONEY:
+      case self::DB_ATTRTYPE_MONEYN:
+      case self::DB_ATTRTYPE_SMALLMONEY:
+      case self::DB_ATTRTYPE_REAL:
         return 'float';
         
-      case DB_ATTRTYPE_SYSNAME:
+      case self::DB_ATTRTYPE_SYSNAME:
         return 'string';
     }
     

--- a/src/main/php/rdbms/mssql/MsSQLDBAdapter.class.php
+++ b/src/main/php/rdbms/mssql/MsSQLDBAdapter.class.php
@@ -1,6 +1,7 @@
 <?php namespace rdbms\mssql;
 
 use rdbms\DBAdapter;
+use rdbms\DBTableAttribute;
 
 
 /**
@@ -20,34 +21,34 @@ class MsSQLDBAdapter extends DBAdapter {
    */
   public function __construct($conn) {
     $this->map= array(
-      'binary'        => DB_ATTRTYPE_BINARY, 
-      'bit'           => DB_ATTRTYPE_BIT,      
-      'char'          => DB_ATTRTYPE_CHAR,     
-      'datetime'      => DB_ATTRTYPE_DATETIME,   
-      'datetimn'      => DB_ATTRTYPE_DATETIMN,   
-      'decimal'       => DB_ATTRTYPE_DECIMAL,    
-      'decimaln'      => DB_ATTRTYPE_DECIMALN,   
-      'float'         => DB_ATTRTYPE_FLOAT,     
-      'floatn'        => DB_ATTRTYPE_FLOATN, 
-      'image'         => DB_ATTRTYPE_IMAGE,     
-      'int'           => DB_ATTRTYPE_INT,      
-      'intn'          => DB_ATTRTYPE_INTN,     
-      'money'         => DB_ATTRTYPE_MONEY,     
-      'moneyn'        => DB_ATTRTYPE_MONEYN, 
-      'nchar'         => DB_ATTRTYPE_NCHAR,     
-      'numeric'       => DB_ATTRTYPE_NUMERIC,    
-      'numericn'      => DB_ATTRTYPE_NUMERICN,   
-      'nvarchar'      => DB_ATTRTYPE_NVARCHAR,   
-      'real'          => DB_ATTRTYPE_REAL,     
-      'smalldatetime' => DB_ATTRTYPE_SMALLDATETIME,
-      'smallint'      => DB_ATTRTYPE_SMALLINT,   
-      'smallmoney'    => DB_ATTRTYPE_SMALLMONEY,
-      'sysname'       => DB_ATTRTYPE_SYSNAME,    
-      'text'          => DB_ATTRTYPE_TEXT,     
-      'timestamp'     => DB_ATTRTYPE_TIMESTAMP,  
-      'tinyint'       => DB_ATTRTYPE_TINYINT,    
-      'varbinary'     => DB_ATTRTYPE_VARBINARY,  
-      'varchar'       => DB_ATTRTYPE_VARCHAR 
+      'binary'        => DBTableAttribute::DB_ATTRTYPE_BINARY,
+      'bit'           => DBTableAttribute::DB_ATTRTYPE_BIT,
+      'char'          => DBTableAttribute::DB_ATTRTYPE_CHAR,
+      'datetime'      => DBTableAttribute::DB_ATTRTYPE_DATETIME,
+      'datetimn'      => DBTableAttribute::DB_ATTRTYPE_DATETIMN,
+      'decimal'       => DBTableAttribute::DB_ATTRTYPE_DECIMAL,
+      'decimaln'      => DBTableAttribute::DB_ATTRTYPE_DECIMALN,
+      'float'         => DBTableAttribute::DB_ATTRTYPE_FLOAT,
+      'floatn'        => DBTableAttribute::DB_ATTRTYPE_FLOATN,
+      'image'         => DBTableAttribute::DB_ATTRTYPE_IMAGE,
+      'int'           => DBTableAttribute::DB_ATTRTYPE_INT,
+      'intn'          => DBTableAttribute::DB_ATTRTYPE_INTN,
+      'money'         => DBTableAttribute::DB_ATTRTYPE_MONEY,
+      'moneyn'        => DBTableAttribute::DB_ATTRTYPE_MONEYN,
+      'nchar'         => DBTableAttribute::DB_ATTRTYPE_NCHAR,
+      'numeric'       => DBTableAttribute::DB_ATTRTYPE_NUMERIC,
+      'numericn'      => DBTableAttribute::DB_ATTRTYPE_NUMERICN,
+      'nvarchar'      => DBTableAttribute::DB_ATTRTYPE_NVARCHAR,
+      'real'          => DBTableAttribute::DB_ATTRTYPE_REAL,
+      'smalldatetime' => DBTableAttribute::DB_ATTRTYPE_SMALLDATETIME,
+      'smallint'      => DBTableAttribute::DB_ATTRTYPE_SMALLINT,
+      'smallmoney'    => DBTableAttribute::DB_ATTRTYPE_SMALLMONEY,
+      'sysname'       => DBTableAttribute::DB_ATTRTYPE_SYSNAME,
+      'text'          => DBTableAttribute::DB_ATTRTYPE_TEXT,
+      'timestamp'     => DBTableAttribute::DB_ATTRTYPE_TIMESTAMP,
+      'tinyint'       => DBTableAttribute::DB_ATTRTYPE_TINYINT,
+      'varbinary'     => DBTableAttribute::DB_ATTRTYPE_VARBINARY,
+      'varchar'       => DBTableAttribute::DB_ATTRTYPE_VARCHAR
     );
     parent::__construct($conn);
   }
@@ -111,7 +112,7 @@ class MsSQLDBAdapter extends DBAdapter {
       // Known bits of status column:
       // 0x08 => NULLable
       // 0x80 => identity column
-      $t->addAttribute(new \rdbms\DBTableAttribute(
+      $t->addAttribute(new DBTableAttribute(
         $record['name'], 
         $this->map[$record['type']],
         ($record['status'] & 0x80), 

--- a/src/main/php/rdbms/mysql/MySQLDBAdapter.class.php
+++ b/src/main/php/rdbms/mysql/MySQLDBAdapter.class.php
@@ -1,6 +1,7 @@
 <?php namespace rdbms\mysql;
 
 use rdbms\DBAdapter;
+use rdbms\DBTableAttribute;
 
 
 /**
@@ -12,31 +13,31 @@ use rdbms\DBAdapter;
  */
 class MySQLDBAdapter extends DBAdapter {
   public static $map= array(
-    'varchar'    => DB_ATTRTYPE_VARCHAR,
-    'varbinary'  => DB_ATTRTYPE_VARCHAR,
-    'char'       => DB_ATTRTYPE_CHAR,
-    'int'        => DB_ATTRTYPE_INT,
-    'bigint'     => DB_ATTRTYPE_NUMERIC,
-    'mediumint'  => DB_ATTRTYPE_SMALLINT,
-    'smallint'   => DB_ATTRTYPE_SMALLINT,
-    'tinyint'    => DB_ATTRTYPE_TINYINT,
-    'bit'        => DB_ATTRTYPE_TINYINT,
-    'date'       => DB_ATTRTYPE_DATE,
-    'datetime'   => DB_ATTRTYPE_DATETIME,
-    'timestamp'  => DB_ATTRTYPE_TIMESTAMP,
-    'tinytext'   => DB_ATTRTYPE_TEXT,
-    'mediumtext' => DB_ATTRTYPE_TEXT,
-    'text'       => DB_ATTRTYPE_TEXT,
-    'longtext'   => DB_ATTRTYPE_TEXT,
-    'enum'       => DB_ATTRTYPE_ENUM,
-    'decimal'    => DB_ATTRTYPE_DECIMAL,
-    'float'      => DB_ATTRTYPE_FLOAT,
-    'double'     => DB_ATTRTYPE_FLOAT,
-    'tinyblob'   => DB_ATTRTYPE_TEXT,
-    'blob'       => DB_ATTRTYPE_TEXT,
-    'mediumblob' => DB_ATTRTYPE_TEXT,
-    'longblob'   => DB_ATTRTYPE_TEXT,
-    'time'       => DB_ATTRTYPE_TEXT
+    'varchar'    => DBTableAttribute::DB_ATTRTYPE_VARCHAR,
+    'varbinary'  => DBTableAttribute::DB_ATTRTYPE_VARCHAR,
+    'char'       => DBTableAttribute::DB_ATTRTYPE_CHAR,
+    'int'        => DBTableAttribute::DB_ATTRTYPE_INT,
+    'bigint'     => DBTableAttribute::DB_ATTRTYPE_NUMERIC,
+    'mediumint'  => DBTableAttribute::DB_ATTRTYPE_SMALLINT,
+    'smallint'   => DBTableAttribute::DB_ATTRTYPE_SMALLINT,
+    'tinyint'    => DBTableAttribute::DB_ATTRTYPE_TINYINT,
+    'bit'        => DBTableAttribute::DB_ATTRTYPE_TINYINT,
+    'date'       => DBTableAttribute::DB_ATTRTYPE_DATE,
+    'datetime'   => DBTableAttribute::DB_ATTRTYPE_DATETIME,
+    'timestamp'  => DBTableAttribute::DB_ATTRTYPE_TIMESTAMP,
+    'tinytext'   => DBTableAttribute::DB_ATTRTYPE_TEXT,
+    'mediumtext' => DBTableAttribute::DB_ATTRTYPE_TEXT,
+    'text'       => DBTableAttribute::DB_ATTRTYPE_TEXT,
+    'longtext'   => DBTableAttribute::DB_ATTRTYPE_TEXT,
+    'enum'       => DBTableAttribute::DB_ATTRTYPE_ENUM,
+    'decimal'    => DBTableAttribute::DB_ATTRTYPE_DECIMAL,
+    'float'      => DBTableAttribute::DB_ATTRTYPE_FLOAT,
+    'double'     => DBTableAttribute::DB_ATTRTYPE_FLOAT,
+    'tinyblob'   => DBTableAttribute::DB_ATTRTYPE_TEXT,
+    'blob'       => DBTableAttribute::DB_ATTRTYPE_TEXT,
+    'mediumblob' => DBTableAttribute::DB_ATTRTYPE_TEXT,
+    'longblob'   => DBTableAttribute::DB_ATTRTYPE_TEXT,
+    'time'       => DBTableAttribute::DB_ATTRTYPE_TEXT
   );
 
   /**
@@ -97,12 +98,12 @@ class MySQLDBAdapter extends DBAdapter {
    */
   public static function tableAttributeFrom($record) {
     preg_match('#^([a-z]+)(\(([0-9,]+)\))?#', $record['Type'], $regs);
-    return new \rdbms\DBTableAttribute(
+    return new DBTableAttribute(
       $record['Field'],                                         // name
       self::$map[$regs[1]],                                     // type
       false !== strpos($record['Extra'], 'auto_increment'),     // identity
       !(empty($record['Null']) || ('NO' == $record['Null'])),   // nullable
-      (int)$regs[3],                                            // length
+      (int)(isset($regs[3]) ? $regs[3] : 0),                    // length
       0,                                                        // precision
       0                                                         // scale
     );

--- a/src/main/php/rdbms/mysqli/MySQLiDBAdapter.class.php
+++ b/src/main/php/rdbms/mysqli/MySQLiDBAdapter.class.php
@@ -1,7 +1,7 @@
 <?php namespace rdbms\mysqli;
 
 use rdbms\DBAdapter;
-
+use rdbms\DBTableAttribute;
 
 /**
  * Adapter for MySQL
@@ -12,30 +12,30 @@ use rdbms\DBAdapter;
  */
 class MySQLiDBAdapter extends DBAdapter {
   public static $map= array(
-    'varchar'    => DB_ATTRTYPE_VARCHAR,
-    'varbinary'  => DB_ATTRTYPE_VARCHAR,
-    'char'       => DB_ATTRTYPE_CHAR,
-    'int'        => DB_ATTRTYPE_INT,
-    'bigint'     => DB_ATTRTYPE_NUMERIC,
-    'mediumint'  => DB_ATTRTYPE_SMALLINT,
-    'smallint'   => DB_ATTRTYPE_SMALLINT,
-    'tinyint'    => DB_ATTRTYPE_TINYINT,
-    'bit'        => DB_ATTRTYPE_TINYINT,
-    'date'       => DB_ATTRTYPE_DATE,
-    'datetime'   => DB_ATTRTYPE_DATETIME,
-    'timestamp'  => DB_ATTRTYPE_TIMESTAMP,
-    'tinytext'   => DB_ATTRTYPE_TEXT,
-    'mediumtext' => DB_ATTRTYPE_TEXT,
-    'text'       => DB_ATTRTYPE_TEXT,
-    'longtext'   => DB_ATTRTYPE_TEXT,
-    'enum'       => DB_ATTRTYPE_ENUM,
-    'decimal'    => DB_ATTRTYPE_DECIMAL,
-    'float'      => DB_ATTRTYPE_FLOAT,
-    'double'     => DB_ATTRTYPE_FLOAT,
-    'tinyblob'   => DB_ATTRTYPE_TEXT,
-    'blob'       => DB_ATTRTYPE_TEXT,
-    'mediumblob' => DB_ATTRTYPE_TEXT,
-    'longblob'   => DB_ATTRTYPE_TEXT
+    'varchar'    => DBTableAttribute::DB_ATTRTYPE_VARCHAR,
+    'varbinary'  => DBTableAttribute::DB_ATTRTYPE_VARCHAR,
+    'char'       => DBTableAttribute::DB_ATTRTYPE_CHAR,
+    'int'        => DBTableAttribute::DB_ATTRTYPE_INT,
+    'bigint'     => DBTableAttribute::DB_ATTRTYPE_NUMERIC,
+    'mediumint'  => DBTableAttribute::DB_ATTRTYPE_SMALLINT,
+    'smallint'   => DBTableAttribute::DB_ATTRTYPE_SMALLINT,
+    'tinyint'    => DBTableAttribute::DB_ATTRTYPE_TINYINT,
+    'bit'        => DBTableAttribute::DB_ATTRTYPE_TINYINT,
+    'date'       => DBTableAttribute::DB_ATTRTYPE_DATE,
+    'datetime'   => DBTableAttribute::DB_ATTRTYPE_DATETIME,
+    'timestamp'  => DBTableAttribute::DB_ATTRTYPE_TIMESTAMP,
+    'tinytext'   => DBTableAttribute::DB_ATTRTYPE_TEXT,
+    'mediumtext' => DBTableAttribute::DB_ATTRTYPE_TEXT,
+    'text'       => DBTableAttribute::DB_ATTRTYPE_TEXT,
+    'longtext'   => DBTableAttribute::DB_ATTRTYPE_TEXT,
+    'enum'       => DBTableAttribute::DB_ATTRTYPE_ENUM,
+    'decimal'    => DBTableAttribute::DB_ATTRTYPE_DECIMAL,
+    'float'      => DBTableAttribute::DB_ATTRTYPE_FLOAT,
+    'double'     => DBTableAttribute::DB_ATTRTYPE_FLOAT,
+    'tinyblob'   => DBTableAttribute::DB_ATTRTYPE_TEXT,
+    'blob'       => DBTableAttribute::DB_ATTRTYPE_TEXT,
+    'mediumblob' => DBTableAttribute::DB_ATTRTYPE_TEXT,
+    'longblob'   => DBTableAttribute::DB_ATTRTYPE_TEXT
   );
 
   /**
@@ -96,7 +96,7 @@ class MySQLiDBAdapter extends DBAdapter {
    */
   public static function tableAttributeFrom($record) {
     preg_match('#^([a-z]+)(\(([0-9,]+)\))?#', $record['Type'], $regs);
-    return new \rdbms\DBTableAttribute(
+    return new DBTableAttribute(
       $record['Field'],                                         // name
       self::$map[$regs[1]],                                     // type
       false !== strpos($record['Extra'], 'auto_increment'),     // identity

--- a/src/main/php/rdbms/pgsql/PostgreSQLDBAdapter.class.php
+++ b/src/main/php/rdbms/pgsql/PostgreSQLDBAdapter.class.php
@@ -1,7 +1,7 @@
 <?php namespace rdbms\pgsql;
 
 use rdbms\DBAdapter;
-
+use rdbms\DBTableAttribute;
 
 /**
  * Adapter for MySQL
@@ -18,27 +18,27 @@ class PostgreSQLDBAdapter extends DBAdapter {
    */
   public function __construct($conn) {
     $this->map= array(
-      'varchar'    => DB_ATTRTYPE_VARCHAR,
-      'char'       => DB_ATTRTYPE_CHAR,
-      'int'        => DB_ATTRTYPE_INT,
-      'int4'       => DB_ATTRTYPE_INT,
-      'bigint'     => DB_ATTRTYPE_NUMERIC,
-      'int8'       => DB_ATTRTYPE_NUMERIC,
-      'mediumint'  => DB_ATTRTYPE_SMALLINT,
-      'smallint'   => DB_ATTRTYPE_SMALLINT,
-      'int2'       => DB_ATTRTYPE_SMALLINT,
-      'tinyint'    => DB_ATTRTYPE_TINYINT,
-      'date'       => DB_ATTRTYPE_DATE,
-      'time'       => DB_ATTRTYPE_DATETIME,
-      'timestamp'  => DB_ATTRTYPE_TIMESTAMP,
-      'mediumtext' => DB_ATTRTYPE_TEXT,
-      'text'       => DB_ATTRTYPE_TEXT,
-      'enum'       => DB_ATTRTYPE_ENUM,
-      'decimal'    => DB_ATTRTYPE_DECIMAL,
-      'float'      => DB_ATTRTYPE_FLOAT,
-      'money'      => DB_ATTRTYPE_MONEY,
-      'numeric'    => DB_ATTRTYPE_NUMERIC,
-      'bool'       => DB_ATTRTYPE_BIT
+      'varchar'    => DBTableAttribute::DB_ATTRTYPE_VARCHAR,
+      'char'       => DBTableAttribute::DB_ATTRTYPE_CHAR,
+      'int'        => DBTableAttribute::DB_ATTRTYPE_INT,
+      'int4'       => DBTableAttribute::DB_ATTRTYPE_INT,
+      'bigint'     => DBTableAttribute::DB_ATTRTYPE_NUMERIC,
+      'int8'       => DBTableAttribute::DB_ATTRTYPE_NUMERIC,
+      'mediumint'  => DBTableAttribute::DB_ATTRTYPE_SMALLINT,
+      'smallint'   => DBTableAttribute::DB_ATTRTYPE_SMALLINT,
+      'int2'       => DBTableAttribute::DB_ATTRTYPE_SMALLINT,
+      'tinyint'    => DBTableAttribute::DB_ATTRTYPE_TINYINT,
+      'date'       => DBTableAttribute::DB_ATTRTYPE_DATE,
+      'time'       => DBTableAttribute::DB_ATTRTYPE_DATETIME,
+      'timestamp'  => DBTableAttribute::DB_ATTRTYPE_TIMESTAMP,
+      'mediumtext' => DBTableAttribute::DB_ATTRTYPE_TEXT,
+      'text'       => DBTableAttribute::DB_ATTRTYPE_TEXT,
+      'enum'       => DBTableAttribute::DB_ATTRTYPE_ENUM,
+      'decimal'    => DBTableAttribute::DB_ATTRTYPE_DECIMAL,
+      'float'      => DBTableAttribute::DB_ATTRTYPE_FLOAT,
+      'money'      => DBTableAttribute::DB_ATTRTYPE_MONEY,
+      'numeric'    => DBTableAttribute::DB_ATTRTYPE_NUMERIC,
+      'bool'       => DBTableAttribute::DB_ATTRTYPE_BIT
     );
     parent::__construct($conn);
   }

--- a/src/main/php/rdbms/sqlite/SQLiteDBAdapter.class.php
+++ b/src/main/php/rdbms/sqlite/SQLiteDBAdapter.class.php
@@ -1,7 +1,7 @@
 <?php namespace rdbms\sqlite;
 
 use rdbms\DBAdapter;
-
+use rdbms\DBTableAttribute;
 
 /**
  * Adapter for SQLite
@@ -21,22 +21,22 @@ class SQLiteDBAdapter extends DBAdapter {
    */
   public function __construct($conn) {
     $this->map= array(
-      'varchar'    => DB_ATTRTYPE_VARCHAR,
-      'char'       => DB_ATTRTYPE_CHAR,
-      'int'        => DB_ATTRTYPE_INT,
-      'integer'    => DB_ATTRTYPE_INT,
-      'bigint'     => DB_ATTRTYPE_NUMERIC,
-      'mediumint'  => DB_ATTRTYPE_SMALLINT,
-      'smallint'   => DB_ATTRTYPE_SMALLINT,
-      'tinyint'    => DB_ATTRTYPE_TINYINT,
-      'date'       => DB_ATTRTYPE_DATE,
-      'datetime'   => DB_ATTRTYPE_DATETIME,
-      'timestamp'  => DB_ATTRTYPE_TIMESTAMP,
-      'mediumtext' => DB_ATTRTYPE_TEXT,
-      'text'       => DB_ATTRTYPE_TEXT,
-      'enum'       => DB_ATTRTYPE_ENUM,
-      'decimal'    => DB_ATTRTYPE_DECIMAL,
-      'float'      => DB_ATTRTYPE_FLOAT
+      'varchar'    => DBTableAttribute::DB_ATTRTYPE_VARCHAR,
+      'char'       => DBTableAttribute::DB_ATTRTYPE_CHAR,
+      'int'        => DBTableAttribute::DB_ATTRTYPE_INT,
+      'integer'    => DBTableAttribute::DB_ATTRTYPE_INT,
+      'bigint'     => DBTableAttribute::DB_ATTRTYPE_NUMERIC,
+      'mediumint'  => DBTableAttribute::DB_ATTRTYPE_SMALLINT,
+      'smallint'   => DBTableAttribute::DB_ATTRTYPE_SMALLINT,
+      'tinyint'    => DBTableAttribute::DB_ATTRTYPE_TINYINT,
+      'date'       => DBTableAttribute::DB_ATTRTYPE_DATE,
+      'datetime'   => DBTableAttribute::DB_ATTRTYPE_DATETIME,
+      'timestamp'  => DBTableAttribute::DB_ATTRTYPE_TIMESTAMP,
+      'mediumtext' => DBTableAttribute::DB_ATTRTYPE_TEXT,
+      'text'       => DBTableAttribute::DB_ATTRTYPE_TEXT,
+      'enum'       => DBTableAttribute::DB_ATTRTYPE_ENUM,
+      'decimal'    => DBTableAttribute::DB_ATTRTYPE_DECIMAL,
+      'float'      => DBTableAttribute::DB_ATTRTYPE_FLOAT
     );
     parent::__construct($conn);
   }

--- a/src/main/php/rdbms/sybase/SybaseDBAdapter.class.php
+++ b/src/main/php/rdbms/sybase/SybaseDBAdapter.class.php
@@ -1,6 +1,7 @@
 <?php namespace rdbms\sybase;
 
 use rdbms\DBAdapter;
+use rdbms\DBTableAttribute;
 
 
 /**
@@ -20,36 +21,37 @@ class SybaseDBAdapter extends DBAdapter {
    */
   public function __construct($conn) {
     $this->map= array(
-      'binary'        => DB_ATTRTYPE_BINARY, 
-      'bit'           => DB_ATTRTYPE_BIT,      
-      'char'          => DB_ATTRTYPE_CHAR,     
-      'datetime'      => DB_ATTRTYPE_DATETIME,   
-      'datetimn'      => DB_ATTRTYPE_DATETIMN,   
-      'decimal'       => DB_ATTRTYPE_DECIMAL,    
-      'decimaln'      => DB_ATTRTYPE_DECIMALN,   
-      'float'         => DB_ATTRTYPE_FLOAT,     
-      'floatn'        => DB_ATTRTYPE_FLOATN, 
-      'image'         => DB_ATTRTYPE_IMAGE,     
-      'int'           => DB_ATTRTYPE_INT,      
-      'intn'          => DB_ATTRTYPE_INTN,     
-      'money'         => DB_ATTRTYPE_MONEY,     
-      'moneyn'        => DB_ATTRTYPE_MONEYN, 
-      'nchar'         => DB_ATTRTYPE_NCHAR,     
-      'numeric'       => DB_ATTRTYPE_NUMERIC,    
-      'numericn'      => DB_ATTRTYPE_NUMERICN,   
-      'nvarchar'      => DB_ATTRTYPE_NVARCHAR,   
-      'real'          => DB_ATTRTYPE_REAL,     
-      'smalldatetime' => DB_ATTRTYPE_SMALLDATETIME,
-      'smallint'      => DB_ATTRTYPE_SMALLINT,   
-      'smallmoney'    => DB_ATTRTYPE_SMALLMONEY,
-      'sysname'       => DB_ATTRTYPE_SYSNAME,    
-      'text'          => DB_ATTRTYPE_TEXT,     
-      'timestamp'     => DB_ATTRTYPE_TIMESTAMP,  
-      'tinyint'       => DB_ATTRTYPE_TINYINT,
-      'unichar'       => DB_ATTRTYPE_CHAR,    
-      'univarchar'    => DB_ATTRTYPE_VARCHAR,
-      'varbinary'     => DB_ATTRTYPE_VARBINARY,  
-      'varchar'       => DB_ATTRTYPE_VARCHAR,
+      'binary'        => DBTableAttribute::DB_ATTRTYPE_BINARY,
+      'bit'           => DBTableAttribute::DB_ATTRTYPE_BIT,
+      'char'          => DBTableAttribute::DB_ATTRTYPE_CHAR,
+      'datetime'      => DBTableAttribute::DB_ATTRTYPE_DATETIME,
+      'datetimn'      => DBTableAttribute::DB_ATTRTYPE_DATETIMN,
+      'decimal'       => DBTableAttribute::DB_ATTRTYPE_DECIMAL,
+      'decimaln'      => DBTableAttribute::DB_ATTRTYPE_DECIMALN,
+      'float'         => DBTableAttribute::DB_ATTRTYPE_FLOAT,
+      'floatn'        => DBTableAttribute::DB_ATTRTYPE_FLOATN,
+      'image'         => DBTableAttribute::DB_ATTRTYPE_IMAGE,
+      'uint'          => DBTableAttribute::DB_ATTRTYPE_INT,
+      'int'           => DBTableAttribute::DB_ATTRTYPE_INT,
+      'intn'          => DBTableAttribute::DB_ATTRTYPE_INTN,
+      'money'         => DBTableAttribute::DB_ATTRTYPE_MONEY,
+      'moneyn'        => DBTableAttribute::DB_ATTRTYPE_MONEYN,
+      'nchar'         => DBTableAttribute::DB_ATTRTYPE_NCHAR,
+      'numeric'       => DBTableAttribute::DB_ATTRTYPE_NUMERIC,
+      'numericn'      => DBTableAttribute::DB_ATTRTYPE_NUMERICN,
+      'nvarchar'      => DBTableAttribute::DB_ATTRTYPE_NVARCHAR,
+      'real'          => DBTableAttribute::DB_ATTRTYPE_REAL,
+      'smalldatetime' => DBTableAttribute::DB_ATTRTYPE_SMALLDATETIME,
+      'smallint'      => DBTableAttribute::DB_ATTRTYPE_SMALLINT,
+      'smallmoney'    => DBTableAttribute::DB_ATTRTYPE_SMALLMONEY,
+      'sysname'       => DBTableAttribute::DB_ATTRTYPE_SYSNAME,
+      'text'          => DBTableAttribute::DB_ATTRTYPE_TEXT,
+      'timestamp'     => DBTableAttribute::DB_ATTRTYPE_TIMESTAMP,
+      'tinyint'       => DBTableAttribute::DB_ATTRTYPE_TINYINT,
+      'unichar'       => DBTableAttribute::DB_ATTRTYPE_CHAR,
+      'univarchar'    => DBTableAttribute::DB_ATTRTYPE_VARCHAR,
+      'varbinary'     => DBTableAttribute::DB_ATTRTYPE_VARBINARY,
+      'varchar'       => DBTableAttribute::DB_ATTRTYPE_VARCHAR,
     );
     parent::__construct($conn);
   }
@@ -113,7 +115,7 @@ class SybaseDBAdapter extends DBAdapter {
       // Known bits of status column:
       // 0x08 => NULLable
       // 0x80 => identity column
-      $t->addAttribute(new \rdbms\DBTableAttribute(
+      $t->addAttribute(new DBTableAttribute(
         $record['name'], 
         $this->map[$record['type']],
         ($record['status'] & 0x80), 
@@ -209,6 +211,8 @@ class SybaseDBAdapter extends DBAdapter {
     if (!$sp_helpconstraint instanceof \rdbms\ResultSet) return $t;
 
     while ($db_constraint= $sp_helpconstraint->next()) {
+      if (!isset($db_constraint['type']) || !isset($db_constraint['definition'])) continue;
+
       if ('referential constraint' != $db_constraint['type']) continue;
       if (0 !== strpos($db_constraint['definition'], $table.' ')) continue;
       $t->addForeignKeyConstraint($this->parseForeignKey($db_constraint));

--- a/src/main/php/rdbms/util/DBXMLNamingContext.class.php
+++ b/src/main/php/rdbms/util/DBXMLNamingContext.class.php
@@ -18,7 +18,7 @@ class DBXMLNamingContext extends \lang\Object {
    *
    * @param   rdbms.DBXMLNamingStrategy s
    */
-  static function setStrategy(\DBXMLNamingStrategy $s) {
+  static function setStrategy(DBXMLNamingStrategy $s) {
     self::$strategy= $s;
   }
 

--- a/src/test/php/rdbms/unittest/mysql/TableDescriptionTest.class.php
+++ b/src/test/php/rdbms/unittest/mysql/TableDescriptionTest.class.php
@@ -1,6 +1,8 @@
 <?php namespace rdbms\unittest\mysql;
 
 use rdbms\mysql\MySQLDBAdapter;
+use rdbms\DBTableAttribute;
+use rdbms\FieldType;
 
 /**
  * TestCase
@@ -12,30 +14,30 @@ class TableDescriptionTest extends \unittest\TestCase {
   #[@test]
   public function auto_increment() {
     $this->assertEquals(
-      new \rdbms\DBTableAttribute('contract_id', DB_ATTRTYPE_INT, true, false, 8, 0, 0),
-      MySQLDBAdapter::tableAttributeFrom(array(
+      new DBTableAttribute('contract_id', FieldType::INT, true, false, 8, 0, 0),
+      MySQLDBAdapter::tableAttributeFrom([
         'Field'   => 'contract_id',
         'Type'    => 'int(8)',
         'Null'    => '',
         'Key'     => 'PRI',
         'Default' => null,
         'Extra'   => 'auto_increment'
-      ))
+      ])
     );
   }
 
   #[@test]
   public function unsigned_int() {
     $this->assertEquals(
-      new \rdbms\DBTableAttribute('bz_id', DB_ATTRTYPE_INT, false, false, 6, 0, 0),
-      MySQLDBAdapter::tableAttributeFrom(array(
+      new DBTableAttribute('bz_id', FieldType::INT, false, false, 6, 0, 0),
+      MySQLDBAdapter::tableAttributeFrom([
         'Field'   => 'bz_id',
         'Type'    => 'int(6) unsigned',
         'Null'    => '',
         'Key'     => '',
         'Default' => 500,
         'Extra'   => ''
-      ))
+      ])
     );
   }
 }


### PR DESCRIPTION
This fixes class-loading issues (constants not defined, because class
only declared, but not used, thus not loaded).

* remove global defines (deprecated, discouraged)
* map uint Sybase data type to DB_ATTRTYPE_INT
* fix class reference