### PR TITLE
Add support for 0x79 tokens - stored procedure return status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 
 language: php
 
+sudo: false
+
 php:
   - 5.5
   - 5.6

--- a/src/main/php/rdbms/tds/TdsV5Protocol.class.php
+++ b/src/main/php/rdbms/tds/TdsV5Protocol.class.php
@@ -269,6 +269,9 @@ class TdsV5Protocol extends TdsProtocol {
       } else if ("\xE3" === $token) {   // ENVCHANGE, e.g. from "use [db]" queries
         $this->envchange();
         return null;
+      } else if ("\x79" === $token) {   // RETURN_STATUS (eg. from stored procedures)
+        $result = $this->stream->getLong();
+        $token= $this->stream->getToken();
       } else {
         throw new TdsProtocolException(
           sprintf('Unexpected token 0x%02X', ord($token)),

--- a/src/main/php/rdbms/tds/TdsV5Protocol.class.php
+++ b/src/main/php/rdbms/tds/TdsV5Protocol.class.php
@@ -269,8 +269,8 @@ class TdsV5Protocol extends TdsProtocol {
       } else if ("\xE3" === $token) {   // ENVCHANGE, e.g. from "use [db]" queries
         $this->envchange();
         return null;
-      } else if ("\x79" === $token) {   // RETURN_STATUS (eg. from stored procedures)
-        $result = $this->stream->getLong();
+      } else if ("\x79" === $token) {   // RETURN_STATUS (eg. from stored procedures), ignore for the moment
+        $this->stream->getLong();
         $token= $this->stream->getToken();
       } else {
         throw new TdsProtocolException(

--- a/src/main/php/rdbms/tds/TdsV7Protocol.class.php
+++ b/src/main/php/rdbms/tds/TdsV7Protocol.class.php
@@ -252,6 +252,9 @@ class TdsV7Protocol extends TdsProtocol {
       } else if ("\xE3" === $token) {   // ENVCHANGE, e.g. from "use [db]" queries
         $this->envchange();
         return null;
+      } else if ("\x79" === $token) {   // RETURN_STATUS (eg. from stored procedures), ignore for the moment
+        $this->stream->getLong();
+        $token= $this->stream->getToken();
       } else {
         throw new TdsProtocolException(
           sprintf('Unexpected token 0x%02X', ord($token)),

--- a/src/test/php/rdbms/unittest/integration/SybaseIntegrationTest.class.php
+++ b/src/test/php/rdbms/unittest/integration/SybaseIntegrationTest.class.php
@@ -203,4 +203,19 @@ class SybaseIntegrationTest extends RdbmsIntegrationTest {
     }
     $this->assertEquals([0 => ['working' => 1]], $conn->select('1 as working'));
   }
+
+  #[@test]
+  public function sp_helpconstraint() {
+    $this->assertTrue($this->db()->query('sp_helpconstraint %c', $this->tableName()));
+  }
+
+  #[@test]
+  public function sp_helpconstraint_and_query() {
+    $q= $this->db()->query('
+      sp_helpconstraint %c
+      select 1 as "result"',
+      $this->tableName()
+    );
+    $this->assertEquals(1, $q->next('result'));
+  }
 }


### PR DESCRIPTION
0x79 is a stored procedure return status; by now, just discard it and fetch next token to be processed.

* [x] Implementation
* [x] Tests