### PR TITLE
Fixed "Fatal error: Class 'Record' not found" error when using projections

### DIFF
--- a/src/main/php/rdbms/Peer.class.php
+++ b/src/main/php/rdbms/Peer.class.php
@@ -257,7 +257,7 @@ class Peer extends \lang\Object {
     $rs= $criteria->executeSelect($this->getConnection(), $this, $jp, $buffered);
 
     // if this is a projection, it does no matter if it's a join or not
-    if ($criteria->isProjection()) return new ResultIterator($rs, 'Record');
+    if ($criteria->isProjection()) return new ResultIterator($rs, '\rdbms\Record');
     if ($criteria->isJoin())       return $jp->getJoinIterator($rs);
     return new ResultIterator($rs, $this->identifier);
   }

--- a/src/test/php/rdbms/unittest/ProjectionTest.class.php
+++ b/src/test/php/rdbms/unittest/ProjectionTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace rdbms\unittest;
 
+use rdbms\DriverManager;
 use unittest\TestCase;
 use util\Date;
 use rdbms\sybase\SybaseConnection;
@@ -16,6 +17,7 @@ use rdbms\unittest\dataset\Job;
  *
  * @see  xp://rdbms.criterion.Projections
  */
+#[@action(new \rdbms\unittest\mock\RegisterMockConnection())]
 class ProjectionTest extends TestCase {
   public
     $syconn = null,
@@ -224,5 +226,17 @@ class ProjectionTest extends TestCase {
     );
     $this->assertFalse($crit->isProjection());
     $this->assertTrue($crit->withProjection(Projections::property(Job::column('job_id')))->isProjection());
+  }
+
+  #[@test]
+  function regressionIteratorDatasetType() {
+    $conn= DriverManager::getConnection('mock://mock/JOBS?autoconnect=1');
+    $crit= (new Criteria())
+      ->withProjection(Projections::count('*'));
+    $this->peer->setConnection($conn);
+    $this->assertEquals(
+      '\rdbms\Record',
+      $this->peer->iteratorFor($crit)->_identifier
+    );
   }
 }


### PR DESCRIPTION
The usage of projections raised an error:

> Fatal error: Class 'Record' not found in /home/idev/dev/xp.private/trunk/xp5/worlds/inside/ea/vendor/xp-framework/rdbms/src/main/php/rdbms/ResultIterator.class.php on line 66