### PR TITLE
MySQL: Change charset to utf8mb4

### DIFF
--- a/src/main/php/rdbms/mysql/MySQLConnection.class.php
+++ b/src/main/php/rdbms/mysql/MySQLConnection.class.php
@@ -99,7 +99,7 @@ class MySQLConnection extends DBConnection {
       throw $e;
     }
 
-    mysql_query('set names UTF8', $this->handle);
+    mysql_query('set names utf8mb4', $this->handle);
 
     // Figure out sql_mode and update formatter's escaperules accordingly
     // - See: http://bugs.mysql.com/bug.php?id=10214

--- a/src/main/php/rdbms/mysqli/MySQLiConnection.class.php
+++ b/src/main/php/rdbms/mysqli/MySQLiConnection.class.php
@@ -92,7 +92,7 @@ class MySQLiConnection extends DBConnection {
       throw $e;
     }
 
-    mysqli_set_charset($this->handle, 'utf8');
+    mysqli_set_charset($this->handle, 'utf8mb4');
 
     // Figure out sql_mode and update formatter's escaperules accordingly
     // - See: http://bugs.mysql.com/bug.php?id=10214

--- a/src/main/php/rdbms/mysqlx/MySqlxConnection.class.php
+++ b/src/main/php/rdbms/mysqlx/MySqlxConnection.class.php
@@ -88,7 +88,7 @@ class MySqlxConnection extends DBConnection {
     }
 
     try {
-      $this->handle->exec('set names UTF8');
+      $this->handle->exec('set names utf8mb4');
 
       // Figure out sql_mode and update formatter's escaperules accordingly
       // - See: http://bugs.mysql.com/bug.php?id=10214

--- a/src/main/php/rdbms/mysqlx/MySqlxProtocol.class.php
+++ b/src/main/php/rdbms/mysqlx/MySqlxProtocol.class.php
@@ -116,7 +116,7 @@ class MySqlxProtocol extends \lang\Object {
       $data= (
         pack('V', $flags).
         pack('V', 1024 * 1024 * 1024).
-        chr(33).                   // Charset 8 = latin1, 33 = utf8
+        chr(224).                  // Charset 8 = latin1, 33 = utf8, 224 = utf8mb4
         str_repeat("\0", 23).      // Filler
         $user."\0".
         ($password ? chr(20).MySqlPassword::$PROTOCOL_41->scramble($password, $init['scramble']) : chr(0))

--- a/src/test/php/rdbms/unittest/integration/MySQLIntegrationTest.class.php
+++ b/src/test/php/rdbms/unittest/integration/MySQLIntegrationTest.class.php
@@ -221,4 +221,12 @@ class MySQLIntegrationTest extends RdbmsIntegrationTest {
 
   #[@test, @ignore('Cast to smallint not supported by MySQL')]
   public function selectSmallintZero() { }
+
+  #[@test]
+  public function selectUtf8mb4() {
+    // Sending characters outside the BMP while the encoding isn't utf8mb4
+    // produces a warning.
+    $this->db()->query("select '💩'");
+    $this->assertEquals(false, $this->db()->query('show warnings')->next());
+  }
 }


### PR DESCRIPTION
MySQL's utf8 charset is broken and only supports characters with up to
three bytes. Strings containing four-byte characters are removed
completely, but no error is thrown.

As utf8mb4 is a superset of utf8, this should not introduce any
compatibility issues. In particular, when inserting into legacy
databases using utf8, strings with four-byte characters will still be
removed silently.