### PR TITLE
Don't make "$result" a member of MySQLiConnection

### DIFF
--- a/src/main/php/rdbms/mysqli/MySQLiConnection.class.php
+++ b/src/main/php/rdbms/mysqli/MySQLiConnection.class.php
@@ -16,7 +16,6 @@ use rdbms\QuerySucceeded;
  * @purpose  Database connection
  */
 class MySQLiConnection extends DBConnection {
-  protected $result= null;
 
   static function __static() {
     if (extension_loaded('mysqli')) {
@@ -182,12 +181,6 @@ class MySQLiConnection extends DBConnection {
       // Check for subsequent connection errors
       if (false === $c) throw new \rdbms\SQLStateException('Previously failed to connect.');
     }
-    
-    // Clean up previous results to prevent "Commands out of sync" errors
-    if (null !== $this->result) {
-      mysqli_free_result($this->result);
-      $this->result= null;
-    }
 
     // Execute query
     $mode= !$buffered || $this->flags & DB_UNBUFFERED;
@@ -209,8 +202,7 @@ class MySQLiConnection extends DBConnection {
     } else if (true === $r) {
       return new QuerySucceeded(mysqli_affected_rows($this->handle));
     } else {
-      $this->result= $r;
-      return new MySQLiResultSet($this->result, $this->tz);
+      return new MySQLiResultSet($r, $this->tz);
     }
   }
 

--- a/src/main/php/rdbms/mysqli/MySQLiResultSet.class.php
+++ b/src/main/php/rdbms/mysqli/MySQLiResultSet.class.php
@@ -106,4 +106,11 @@ class MySQLiResultSet extends ResultSet {
     $this->handle= null;
     return $r;
   }
+
+  /**
+   * Automatically close resultset and free result memory when resultset object is destroyed
+   */
+  public function __destruct() {
+    $this->close();
+  }
 }

--- a/src/test/php/rdbms/unittest/integration/RdbmsIntegrationTest.class.php
+++ b/src/test/php/rdbms/unittest/integration/RdbmsIntegrationTest.class.php
@@ -715,7 +715,7 @@ abstract class RdbmsIntegrationTest extends TestCase {
     $this->createTable();
     $db= $this->db();
 
-    $q= $db->open('select * from %c', $this->tableName());
+    $q= $db->query('select * from %c', $this->tableName());
     $this->assertEquals(['pk' => 1, 'username' => 'kiesel'], $q->next());
 
     $this->assertEquals(1, $db->query('select 1 as num')->next('num'));


### PR DESCRIPTION
Don't make "$result" a member of MySQLiConnection as it will always empty a previous result when issuing the next query. Instead use phps magic method "__destruct" in MySQLiResultSet to automatically close the resultset and free result memory on object destruction. 

example:

```
// get db connection
$db = rdbms\ConnectionManager::getInstance()->getByHost('somedsn', 0);

// result contains tables;
$result = $db->query('SHOW TABLES');

// MySQLiConnection::query0 empties previous result by using mysqli_free_result($this->result)
$db->query('SET NAMES utf8');

// result is now bool(false)
var_dump($result->next());
```
