### PR TITLE
MySQL: Buffered queries inconsistency

### DIFF
--- a/src/main/php/rdbms/mysqli/MySQLiConnection.class.php
+++ b/src/main/php/rdbms/mysqli/MySQLiConnection.class.php
@@ -208,6 +208,8 @@ class MySQLiConnection extends DBConnection {
       }
     } else if (true === $r) {
       return new QuerySucceeded(mysqli_affected_rows($this->handle));
+    } else if ($buffered) {
+      return new MySQLiResultSet($r, $this->tz);
     } else {
       $this->result= $r;
       return new MySQLiResultSet($this->result, $this->tz);

--- a/src/test/php/rdbms/unittest/integration/RdbmsIntegrationTest.class.php
+++ b/src/test/php/rdbms/unittest/integration/RdbmsIntegrationTest.class.php
@@ -701,6 +701,17 @@ abstract class RdbmsIntegrationTest extends TestCase {
   }
 
   #[@test]
+  public function consecutiveQueryDoesNotAffectBufferedResults() {
+    $this->createTable();
+    $db= $this->db();
+
+    $result= $db->query('select * from %c where pk = 2', $this->tableName());
+    $db->query('update %c set username = "test" where pk = 1', $this->tableName());
+
+    $this->assertEquals([['pk' => 2, 'username' => 'kiesel']], iterator_to_array($result));
+  }
+
+  #[@test]
   public function unbufferedReadNoResults() {
     $this->createTable();
     $db= $this->db();


### PR DESCRIPTION
## What's in it
This pull request fixes implementation inconsistencies for buffered queries in MySQL.

```php
$result= $conn->query('select ...');
$conn->query('update ...');

foreach ($result as $record) {
  // Work with $record
}
```

With the userland and `ext/mysql` based drivers, this works as expected; while with *mysqli*, the result is always empty.

This is due to handling in *mysqli* for "commands out of sync errors" which are caused by not reading unbuffered queries started with `open()` until the end before issuing another query. See https://github.com/xp-framework/rdbms/pull/30 for more details.

## Tests
The old (and [deprecated](https://wiki.php.net/rfc/mysql_deprecation)) `ext/mysql`-based implementation:

```sh
$ MYSQL_DSN=mysql+std://travis:*****@127.0.0.1:3306/test xp test -s fail src/test/php/
# ... 

♥: 726/1239 run (513 skipped), 726 succeeded, 0 failed
Memory used: 12441.69 kB (12539.88 kB peak)
Time taken: 1.693 seconds
```

MySQL improved:
```sh
$ MYSQL_DSN=mysql+i://travis:*****@127.0.0.1:3306/test xp test -s fail src/test/php/
# ... 

♥: 726/1239 run (513 skipped), 726 succeeded, 0 failed
Memory used: 10105.55 kB (10158.24 kB peak)
Time taken: 1.478 seconds
```

Userland protocol implementation:
```sh
$ MYSQL_DSN=mysql+x://travis:*****@127.0.0.1:3306/test xp test -s fail src/test/php/
# ... 

♥: 726/1239 run (513 skipped), 726 succeeded, 0 failed
Memory used: 10103.17 kB (10155.86 kB peak)
Time taken: 1.456 seconds
```