### PR TITLE
Return `null` instead of `false` from ResultSet::next() at EOF

### DIFF
--- a/src/main/php/rdbms/CachedResults.class.php
+++ b/src/main/php/rdbms/CachedResults.class.php
@@ -22,7 +22,7 @@ class CachedResults extends \lang\Object implements \util\XPIterator {
    * @return  bool
    */
   public function hasNext() {
-    return !is_null($this->_key);
+    return null !== $this->_key;
   }
   
   /**

--- a/src/main/php/rdbms/ResultIterator.class.php
+++ b/src/main/php/rdbms/ResultIterator.class.php
@@ -55,7 +55,7 @@ class ResultIterator extends \lang\Object implements \util\XPIterator {
       $this->_record= $this->_rs->next();
       // Fall through
     }
-    if (false === $this->_record) {
+    if (null === $this->_record) {
       throw new NoSuchElementException('No more elements');
     }
     

--- a/src/main/php/rdbms/ResultSet.class.php
+++ b/src/main/php/rdbms/ResultSet.class.php
@@ -55,7 +55,7 @@ abstract class ResultSet extends \lang\Object implements Closeable, \IteratorAgg
    * no more rows are available.
    *
    * @param   string $field default NULL
-   * @return  var
+   * @return  [:var]
    */
   public abstract function next($field= null);
 

--- a/src/main/php/rdbms/ibase/InterBaseResultSet.class.php
+++ b/src/main/php/rdbms/ibase/InterBaseResultSet.class.php
@@ -47,14 +47,14 @@ class InterbaseResultSet extends ResultSet {
    * no more rows are available.
    *
    * @param   string field default NULL
-   * @return  var
+   * @return  [:var]
    */
   public function next($field= null) {
     if (
       !is_resource($this->handle) ||
       false === ($row= ibase_fetch_assoc($this->handle))
     ) {
-      return false;
+      return null;
     }
 
     foreach (array_keys($row) as $key) {

--- a/src/main/php/rdbms/join/JoinIterator.class.php
+++ b/src/main/php/rdbms/join/JoinIterator.class.php
@@ -36,7 +36,7 @@ class JoinIterator extends \lang\Object implements \util\XPIterator, JoinExtract
    * @return  bool
    */
   public function hasNext() {
-    return (false !== $this->record);
+    return (null !== $this->record);
   }
   
   /**

--- a/src/main/php/rdbms/mssql/MsSQLResultSet.class.php
+++ b/src/main/php/rdbms/mssql/MsSQLResultSet.class.php
@@ -47,14 +47,14 @@ class MsSQLResultSet extends ResultSet {
    * no more rows are available.
    *
    * @param   string field default NULL
-   * @return  var
+   * @return  [:var]
    */
   public function next($field= null) {
     if (
       !is_resource($this->handle) ||
       false === ($row= mssql_fetch_assoc($this->handle))
     ) {
-      return false;
+      return null;
     }
 
     foreach ($row as $key => $value) {

--- a/src/main/php/rdbms/mysql/MySQLResultSet.class.php
+++ b/src/main/php/rdbms/mysql/MySQLResultSet.class.php
@@ -47,14 +47,14 @@ class MySQLResultSet extends ResultSet {
    * no more rows are available.
    *
    * @param   string field default NULL
-   * @return  var
+   * @return  [:var]
    */
   public function next($field= null) {
     if (
       !is_resource($this->handle) ||
       false === ($row= mysql_fetch_assoc($this->handle))
     ) {
-      return false;
+      return null;
     }
     
     foreach (array_keys($row) as $key) {

--- a/src/main/php/rdbms/mysqli/MySQLiResultSet.class.php
+++ b/src/main/php/rdbms/mysqli/MySQLiResultSet.class.php
@@ -49,14 +49,14 @@ class MySQLiResultSet extends ResultSet {
    * no more rows are available.
    *
    * @param   string field default NULL
-   * @return  var
+   * @return  [:var]
    */
   public function next($field= null) {
     if (
       !is_object($this->handle) ||
       null === ($row= mysqli_fetch_assoc($this->handle))
     ) {
-      return false;
+      return null;
     }
     
     foreach (array_keys($row) as $key) {

--- a/src/main/php/rdbms/mysqlx/MySqlxBufferedResultSet.class.php
+++ b/src/main/php/rdbms/mysqlx/MySqlxBufferedResultSet.class.php
@@ -43,10 +43,10 @@ class MySqlxBufferedResultSet extends AbstractMysqlxResultSet {
    * no more rows are available.
    *
    * @param   string field default NULL
-   * @return  var
+   * @return  [:var]
    */
   public function next($field= null) {
-    if ($this->offset >= $this->length) return false;
+    if ($this->offset >= $this->length) return null;
     
     return $this->record($this->records[$this->offset++], $field);
   }

--- a/src/main/php/rdbms/mysqlx/MySqlxResultSet.class.php
+++ b/src/main/php/rdbms/mysqlx/MySqlxResultSet.class.php
@@ -24,12 +24,12 @@ class MySQLxResultSet extends AbstractMysqlxResultSet {
    * no more rows are available.
    *
    * @param   string field default NULL
-   * @return  var
+   * @return  [:var]
    */
   public function next($field= null) {
     if (null === $this->handle || null === ($record= $this->handle->fetch($this->fields))) {
       $this->handle= null;
-      return false;
+      return null;
     }
     
     return $this->record($record, $field);

--- a/src/main/php/rdbms/pgsql/PostgreSQLResultSet.class.php
+++ b/src/main/php/rdbms/pgsql/PostgreSQLResultSet.class.php
@@ -2,12 +2,10 @@
 
 use rdbms\ResultSet;
 
-
 /**
  * Result set
  *
- * @ext      pgsql
- * @purpose  Resultset wrapper
+ * @ext   pgsql
  */
 class PostgreSQLResultSet extends ResultSet {
 
@@ -46,14 +44,14 @@ class PostgreSQLResultSet extends ResultSet {
    * no more rows are available.
    *
    * @param   string field default NULL
-   * @return  var
+   * @return  [:var]
    */
   public function next($field= null) {
     if (
       !is_resource($this->handle) ||
       false === ($row= pg_fetch_assoc($this->handle))
     ) {
-      return false;
+      return null;
     }
     
     foreach ($row as $key => $value) {

--- a/src/main/php/rdbms/sqlite3/SQLite3ResultSet.class.php
+++ b/src/main/php/rdbms/sqlite3/SQLite3ResultSet.class.php
@@ -45,14 +45,14 @@ class SQLite3ResultSet extends ResultSet {
    * no more rows are available.
    *
    * @param   string field default NULL
-   * @return  var
+   * @return  [:var]
    */
   public function next($field= null) {
     if (
       !$this->handle instanceof \SQLite3Result ||
       false === ($row= $this->handle->fetchArray(SQLITE3_ASSOC))
     ) {
-      return false;
+      return null;
     }
 
     foreach ($row as $key => $value) {

--- a/src/main/php/rdbms/sqlsrv/SqlSrvResultSet.class.php
+++ b/src/main/php/rdbms/sqlsrv/SqlSrvResultSet.class.php
@@ -51,14 +51,14 @@ class SqlSrvResultSet extends ResultSet {
    * no more rows are available.
    *
    * @param   string field default NULL
-   * @return  var
+   * @return  [:var]
    */
   public function next($field= null) {
     if (
       !is_resource($this->handle) ||
       !is_array($row= sqlsrv_fetch_array($this->handle, SQLSRV_FETCH_ASSOC))
     ) {
-      return false;
+      return null;
     }
 
     foreach ($row as $key => $value) {

--- a/src/main/php/rdbms/sybase/SybaseResultSet.class.php
+++ b/src/main/php/rdbms/sybase/SybaseResultSet.class.php
@@ -47,14 +47,14 @@ class SybaseResultSet extends ResultSet {
    * no more rows are available.
    *
    * @param   string field default NULL
-   * @return  var
+   * @return  [:var]
    */
   public function next($field= null) {
     if (
       !is_resource($this->handle) ||
       false === ($row= sybase_fetch_assoc($this->handle))
     ) {
-      return false;
+      return null;
     }
 
     foreach (array_keys($row) as $key) {

--- a/src/main/php/rdbms/tds/TdsBufferedResultSet.class.php
+++ b/src/main/php/rdbms/tds/TdsBufferedResultSet.class.php
@@ -54,10 +54,10 @@ class TdsBufferedResultSet extends AbstractTdsResultSet {
    * no more rows are available.
    *
    * @param   string field default NULL
-   * @return  var
+   * @return  [:var]
    */
   public function next($field= null) {
-    if ($this->offset >= $this->length) return false;
+    if ($this->offset >= $this->length) return null;
     
     $record= $this->records[$this->offset++];
     if ($record instanceof SQLException) {

--- a/src/main/php/rdbms/tds/TdsResultSet.class.php
+++ b/src/main/php/rdbms/tds/TdsResultSet.class.php
@@ -25,13 +25,13 @@ class TdsResultSet extends AbstractTdsResultSet {
    * no more rows are available.
    *
    * @param   string field default NULL
-   * @return  var
+   * @return  [:var]
    */
   public function next($field= null) {
     try {
       if (null === $this->handle || null === ($record= $this->handle->fetch($this->fields))) {
         $this->handle= null;
-        return false;
+        return null;
       }
     } catch (ProtocolException $e) {
       throw new SQLException('Failed reading row', $e);

--- a/src/test/php/rdbms/unittest/integration/MySQLIntegrationTest.class.php
+++ b/src/test/php/rdbms/unittest/integration/MySQLIntegrationTest.class.php
@@ -240,6 +240,6 @@ class MySQLIntegrationTest extends RdbmsIntegrationTest {
     // Sending characters outside the BMP while the encoding isn't utf8mb4
     // produces a warning.
     $this->assertEquals('💩', $this->db()->query("select '💩' as poop")->next('poop'));
-    $this->assertEquals(false, $this->db()->query('show warnings')->next());
+    $this->assertNull($this->db()->query('show warnings')->next());
   }
 }

--- a/src/test/php/rdbms/unittest/integration/RdbmsIntegrationTest.class.php
+++ b/src/test/php/rdbms/unittest/integration/RdbmsIntegrationTest.class.php
@@ -191,7 +191,7 @@ abstract class RdbmsIntegrationTest extends TestCase {
     $this->createTable();
     $q= $this->db()->query('select * from %c where 1 = 0', $this->tableName());
     $this->assertInstanceOf(ResultSet::class, $q);
-    $this->assertEquals(false, $q->next());
+    $this->assertNull($q->next());
   }
 
   #[@test]

--- a/src/test/php/rdbms/unittest/mock/MockResultSet.class.php
+++ b/src/test/php/rdbms/unittest/mock/MockResultSet.class.php
@@ -39,10 +39,10 @@ class MockResultSet extends \rdbms\ResultSet {
    * no more rows are available.
    *
    * @param   string $field default NULL
-   * @return  var
+   * @return  [:var]
    */
   public function next($field= null) {
-    if ($this->offset >= sizeof($this->data)) return false;
+    if ($this->offset >= sizeof($this->data)) return null;
     $this->offset++;
     
     if ($field) {

--- a/src/test/php/rdbms/unittest/mysql/MySqlxBufferedResultSetTest.class.php
+++ b/src/test/php/rdbms/unittest/mysql/MySqlxBufferedResultSetTest.class.php
@@ -74,7 +74,7 @@ class MySqlxBufferedResultSetTest extends \unittest\TestCase {
     $records= [
     ];
     $fixture= $this->newResultSet($records);
-    $this->assertFalse($fixture->next());
+    $this->assertNull($fixture->next());
   }
 
   #[@test]
@@ -107,7 +107,7 @@ class MySqlxBufferedResultSetTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function next_returns_false_at_end() { 
+  public function next_returns_null_at_end() { 
     $records= [
       [
         'id'   => 6100,
@@ -116,7 +116,7 @@ class MySqlxBufferedResultSetTest extends \unittest\TestCase {
     ];
     $fixture= $this->newResultSet($records);
     $fixture->next();
-    $this->assertFalse($fixture->next());
+    $this->assertNull($fixture->next());
   }
 
   #[@test]

--- a/src/test/php/rdbms/unittest/sqlite3/SQLite3ConnectionTest.class.php
+++ b/src/test/php/rdbms/unittest/sqlite3/SQLite3ConnectionTest.class.php
@@ -72,7 +72,7 @@ class SQLite3ConnectionTest extends \unittest\TestCase {
     $result= $this->conn->query('select 1 where 1 = 0');
 
     $this->assertInstanceOf(SQLite3ResultSet::class, $result);
-    $this->assertFalse($result->next());
+    $this->assertNull($result->next());
   }
 
   #[@test]

--- a/src/test/php/rdbms/unittest/tds/TdsBufferedResultSetTest.class.php
+++ b/src/test/php/rdbms/unittest/tds/TdsBufferedResultSetTest.class.php
@@ -75,7 +75,7 @@ class TdsBufferedResultSetTest extends \unittest\TestCase {
     $records= [
     ];
     $fixture= $this->newResultSet($records);
-    $this->assertFalse($fixture->next());
+    $this->assertNull($fixture->next());
   }
 
   #[@test]
@@ -108,7 +108,7 @@ class TdsBufferedResultSetTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function next_returns_false_at_end() { 
+  public function next_returns_null_at_end() { 
     $records= [
       [
         'id'   => 6100,
@@ -117,7 +117,7 @@ class TdsBufferedResultSetTest extends \unittest\TestCase {
     ];
     $fixture= $this->newResultSet($records);
     $fixture->next();
-    $this->assertFalse($fixture->next());
+    $this->assertNull($fixture->next());
   }
 
   #[@test]


### PR DESCRIPTION
## In a nutshell

The `next()` method will return **NULL** at the end of the iteration instead of *FALSE*. This changes the return type to be a nullable array instead of *array OR false*.

## Implications

Although this is theoretically is a BC break typical code written as follows is not affected:

```php
$q= $conn->query('...');
while ($record= $q->next()) {
  // ...
}
```