### PR TITLE
Implemented TDS_LONGCHAR

### DIFF
--- a/src/main/php/rdbms/tds/TdsV5Protocol.class.php
+++ b/src/main/php/rdbms/tds/TdsV5Protocol.class.php
@@ -79,15 +79,16 @@ class TdsV5Protocol extends TdsProtocol {
     $records[self::T_LONGCHAR]= newinstance('rdbms.tds.TdsRecord', [], '{
       public function unmarshal($stream, $field, $records) {
         $len= $stream->getLong();
-        $chars= null;
-        if ($len !== 0) {
+        if ($len === 0) {
+          return null;
+        } else {
           if (\xp::ENCODING === $field["conv"]) {
             $chars= $stream->read($len);
           } else {
             $chars= iconv($field["conv"], \xp::ENCODING, $stream->read($len));
           }
-        }
-        return $chars === " " ? "" : $chars;
+          return $chars === " " ? "" : $chars;
+        } 
       }
     }');
     return $records;

--- a/src/main/php/rdbms/tds/TdsV5Protocol.class.php
+++ b/src/main/php/rdbms/tds/TdsV5Protocol.class.php
@@ -8,6 +8,8 @@
  */
 class TdsV5Protocol extends TdsProtocol {
 
+  const T_LONGCHAR = 0xAF;
+
   static function __static() { }
 
   /**
@@ -72,6 +74,20 @@ class TdsV5Protocol extends TdsProtocol {
       public function unmarshal($stream, $field, $records) {
         $len= $stream->getLong();
         return $stream->getString($len / 2);
+      }
+    }');
+    $records[self::T_LONGCHAR]= newinstance('rdbms.tds.TdsRecord', [], '{
+      public function unmarshal($stream, $field, $records) {
+        $len= $stream->getLong();
+        $chars= null;
+        if ($len !== 0) {
+          if (\xp::ENCODING === $field["conv"]) {
+            $chars= $stream->read($len);
+          } else {
+            $chars= iconv($field["conv"], \xp::ENCODING, $stream->read($len));
+          }
+        }
+        return $chars === " " ? "" : $chars;
       }
     }');
     return $records;

--- a/src/test/php/rdbms/unittest/integration/SybaseIntegrationTest.class.php
+++ b/src/test/php/rdbms/unittest/integration/SybaseIntegrationTest.class.php
@@ -208,4 +208,16 @@ class SybaseIntegrationTest extends RdbmsIntegrationTest {
     );
     $this->assertEquals(1, $q->next('result'));
   }
+
+  #[@test]
+  public function longcharImplementationRegression() {
+    $this->assertEquals([
+      'field1' => 'foo',
+      'field2' => 'bar'
+    ], $this->db()->query('
+      select
+        convert(varchar(5000), "foo") as "field1",
+        "bar" as "field2"
+    ')->next());
+  }
 }


### PR DESCRIPTION
See Sybase-tds38-102306.pdf / Page 184

The Type implemented in TdsProtocol for 0xAF (handled the same as XT_VARCHAR 0xA7) has an "length" field of 4 bytes. TDS_LONGCHAR needs 8 bytes. Also the "null" handling is a little bit different:

length=1, content=" " => Empty string
length=0 => null

Regarding to http://www.freetds.org/tds.html#types, the implementation of 0xA7 is correct for TdsV7

Reproduce error caused by the wrong implementation:

`select
          convert(varchar(5000), "foo") as "field1",
          "bar" as "field2"`

In the result half of field1 is written in field2.



