### PR TITLE
XP9 Compat

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,10 @@ RDBMS support for the XP Framework: MySQL, Sybase, MSSQL, PostgreSQL, SQLite3, I
 
 ## ?.?.? / ????-??-??
 
+## 10.0.0 / 2017-05-29
+
+* Merged PR #39: XP9 Compatibility - @thekid
+
 ## 9.0.8 / 2017-05-20
 
 * Refactored code to use `typeof()` instead of `xp::typeOf()`, see

--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,14 @@
   "description" : "RDBMS support for the XP Framework",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^8.0 | ^7.0 | ^6.11",
+    "xp-framework/core": "^9.0 | ^8.0 | ^7.0 | ^6.11",
     "xp-framework/logging": "^7.0 | ^6.5",
-    "xp-framework/networking": "^8.0 | ^7.0 | ^6.6",
+    "xp-framework/networking": "^9.0 | ^8.0 | ^7.0 | ^6.6",
     "xp-framework/math": "^7.0 | ^6.6",
     "php" : ">=5.6.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^7.0 | ^6.5"
+    "xp-framework/unittest": "^9.0 | ^8.0 | ^7.0 | ^6.5"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "xp-framework/core": "^9.0 | ^8.0 | ^7.0 | ^6.11",
     "xp-framework/logging": "^8.0 | ^7.0 | ^6.5",
     "xp-framework/networking": "^9.0 | ^8.0 | ^7.0 | ^6.6",
-    "xp-framework/math": "^7.0 | ^6.6",
+    "xp-framework/math": "^8.0 | ^7.0 | ^6.6",
     "php" : ">=5.6.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^9.0 | ^8.0 | ^7.0 | ^6.11",
-    "xp-framework/logging": "^7.0 | ^6.5",
+    "xp-framework/logging": "^8.0 | ^7.0 | ^6.5",
     "xp-framework/networking": "^9.0 | ^8.0 | ^7.0 | ^6.6",
     "xp-framework/math": "^7.0 | ^6.6",
     "php" : ">=5.6.0"

--- a/src/main/php/rdbms/CachedResults.class.php
+++ b/src/main/php/rdbms/CachedResults.class.php
@@ -1,6 +1,6 @@
 <?php namespace rdbms;
 
-class CachedResults extends \lang\Object implements \util\XPIterator {
+class CachedResults implements \util\XPIterator {
   private $_hash, $_key;
 
   /**

--- a/src/main/php/rdbms/Column.class.php
+++ b/src/main/php/rdbms/Column.class.php
@@ -14,7 +14,7 @@ use rdbms\criterion\Restrictions;
  *   $criteria= create(new Criteria())->add($col->equal(5));
  * </code>
  */
-class Column extends \lang\Object implements SQLFragment {
+class Column implements SQLFragment {
   private
     $peer= null,
     $type= '',

--- a/src/main/php/rdbms/ConnectionManager.class.php
+++ b/src/main/php/rdbms/ConnectionManager.class.php
@@ -8,7 +8,7 @@ use rdbms\DSN;
  *
  * @test    xp://net.xp_framework.rdbms.ConnectionManagerTest
  */
-class ConnectionManager extends \lang\Object implements Configurable {
+class ConnectionManager implements Configurable {
   protected static $instance= null;
   public $pool= [];
 

--- a/src/main/php/rdbms/Criteria.class.php
+++ b/src/main/php/rdbms/Criteria.class.php
@@ -14,7 +14,7 @@ define('DESCENDING',      'desc');
  * @test  xp://net.xp_framework.unittest.rdbms.CriteriaTest
  * @see   xp://rdbms.DataSet
  */
-class Criteria extends \lang\Object implements SQLExpression {
+class Criteria implements SQLExpression {
   public 
     $conditions   = [],
     $orderings    = [],

--- a/src/main/php/rdbms/DBAdapter.class.php
+++ b/src/main/php/rdbms/DBAdapter.class.php
@@ -8,7 +8,7 @@
  * @see      xp://rdbms.DBTable
  * @purpose  RDBMS reflection
  */  
-abstract class DBAdapter extends \lang\Object {
+abstract class DBAdapter {
   public
     $conn=  null;
     

--- a/src/main/php/rdbms/DBConstraint.class.php
+++ b/src/main/php/rdbms/DBConstraint.class.php
@@ -3,7 +3,7 @@
 /**
  * Represents a database constaint
  */
-abstract class DBConstraint extends \lang\Object {
+abstract class DBConstraint {
 
   public 
     $name= '';

--- a/src/main/php/rdbms/DBEvent.class.php
+++ b/src/main/php/rdbms/DBEvent.class.php
@@ -5,7 +5,7 @@
  *
  * @purpose  Wrap database events
  */
-class DBEvent extends \lang\Object {
+class DBEvent {
   const
     CONNECT   = 'connect',
     CONNECTED = 'connected',

--- a/src/main/php/rdbms/DBIndex.class.php
+++ b/src/main/php/rdbms/DBIndex.class.php
@@ -4,7 +4,7 @@
  * Class representing an index
  *
  */
-class DBIndex extends \lang\Object {
+class DBIndex {
   public
     $name=     '',
     $keys=     [],

--- a/src/main/php/rdbms/DBTable.class.php
+++ b/src/main/php/rdbms/DBTable.class.php
@@ -6,7 +6,7 @@
  * Represents a database table
  *
  */  
-class DBTable extends \lang\Object {
+class DBTable {
   public 
     $name=          '',
     $attributes=    [],

--- a/src/main/php/rdbms/DBTableAttribute.class.php
+++ b/src/main/php/rdbms/DBTableAttribute.class.php
@@ -5,7 +5,7 @@
  *
  * @see   xp://rdbms.DBTable
  */
-class DBTableAttribute extends \lang\Object {
+class DBTableAttribute {
   public 
     $name=        '',
     $type=        -1,

--- a/src/main/php/rdbms/DataSet.class.php
+++ b/src/main/php/rdbms/DataSet.class.php
@@ -1,6 +1,8 @@
 <?php namespace rdbms;
 
 use rdbms\join\JoinExtractable;
+use lang\Value;
+use util\Objects;
 
 /**
  * A dataset represents a row of data selected from a database. Dataset 
@@ -72,7 +74,7 @@ use rdbms\join\JoinExtractable;
  * @see      xp://rdbms.ConnectionManager
  * @purpose  Base class
  */
-abstract class DataSet extends \lang\Object implements JoinExtractable {
+abstract class DataSet implements Value, JoinExtractable {
   public
     $_new         = true,
     $_changed     = [];
@@ -374,5 +376,24 @@ abstract class DataSet extends \lang\Object implements JoinExtractable {
     $affected= $peer->doDelete($criteria);
     $this->_changed= [];
     return $affected;
+  }
+
+  /**
+   * Returns a hashcode for this object
+   *
+   * @return  string
+   */
+  public function hashCode() {
+    return 'D'.Objects::hashOf((array)$this);
+  }
+
+  /**
+   * Compares this DSN to another given value
+   *
+   * @param  var $value
+   * @return int
+   */    
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare((array)$this, (array)$value) : 1;
   }
 }

--- a/src/main/php/rdbms/DriverImplementationsProvider.class.php
+++ b/src/main/php/rdbms/DriverImplementationsProvider.class.php
@@ -5,7 +5,7 @@
  *
  * @see   xp://rdbms.DefaultDrivers
  */
-abstract class DriverImplementationsProvider extends \lang\Object {
+abstract class DriverImplementationsProvider {
   protected $parent= null;
 
   /**

--- a/src/main/php/rdbms/DriverManager.class.php
+++ b/src/main/php/rdbms/DriverManager.class.php
@@ -65,7 +65,7 @@
  *
  * @test     xp://net.xp_framework.unittest.rdbms.DriverManagerTest
  */
-class DriverManager extends \lang\Object {
+class DriverManager {
   protected static $instance= null;
   public $drivers= [];
   protected $lookup= [];

--- a/src/main/php/rdbms/FieldType.class.php
+++ b/src/main/php/rdbms/FieldType.class.php
@@ -5,7 +5,7 @@
  *
  * @purpose  Enumeration
  */
-class FieldType extends \lang\Object {
+class FieldType {
   const BINARY =         0x0000;             
   const BIT =            0x0001;               
   const CHAR =           0x0002;              

--- a/src/main/php/rdbms/Peer.class.php
+++ b/src/main/php/rdbms/Peer.class.php
@@ -14,7 +14,7 @@
  * @test  xp://net.xp_framework.unittest.rdbms.DataSetTest
  * @see   xp://rdbms.DataSet
  */
-class Peer extends \lang\Object {
+class Peer {
   protected static 
     $instance   = [];
 

--- a/src/main/php/rdbms/ProfilingObserver.class.php
+++ b/src/main/php/rdbms/ProfilingObserver.class.php
@@ -12,7 +12,7 @@ use lang\IllegalArgumentException;
  * Attach to database by appending `&observer[rdbms.ProfilingObserver]=default` where
  * `default` denotes the log category to log to.
  */
-class ProfilingObserver extends \lang\Object implements Observer, Traceable {
+class ProfilingObserver implements Observer, Traceable {
   const COUNT= 0x01;
   const TIMES= 0x02;
 

--- a/src/main/php/rdbms/Record.class.php
+++ b/src/main/php/rdbms/Record.class.php
@@ -3,7 +3,7 @@
 /**
  * A Record saves key value pairs
  */
-class Record extends \lang\Object {
+class Record {
   
   /**
    * Constructor. Supports the array syntax, where an associative

--- a/src/main/php/rdbms/ResultIterator.class.php
+++ b/src/main/php/rdbms/ResultIterator.class.php
@@ -8,7 +8,7 @@ use util\NoSuchElementException;
  * @test  xp://net.xp_framework.unittest.rdbms.DataSetTest
  * @see   xp://rdbms.Peer
  */
-class ResultIterator extends \lang\Object implements \util\XPIterator {
+class ResultIterator implements \util\XPIterator {
   public
     $_rs         = null,
     $_identifier = '',

--- a/src/main/php/rdbms/ResultSet.class.php
+++ b/src/main/php/rdbms/ResultSet.class.php
@@ -17,7 +17,7 @@ use lang\Closeable;
  *
  * @test  xp://rdbms.unittest.ResultSetTest
  */
-abstract class ResultSet extends \lang\Object implements Closeable, \IteratorAggregate {
+abstract class ResultSet implements Closeable, \IteratorAggregate {
   protected $handle, $fields, $tz;
   private $iterator= null;
 

--- a/src/main/php/rdbms/ResultSetIterator.class.php
+++ b/src/main/php/rdbms/ResultSetIterator.class.php
@@ -5,7 +5,7 @@
  *
  * @test xp://rdbms.unittest.ResultSetTest
  */
-class ResultSetIterator extends \lang\Object implements \Iterator {
+class ResultSetIterator implements \Iterator {
   const EOF = -1;
   protected $rs, $offset, $current;
 

--- a/src/main/php/rdbms/SQLDialect.class.php
+++ b/src/main/php/rdbms/SQLDialect.class.php
@@ -8,7 +8,7 @@
  * @test     xp://net.xp_framework.unittest.rdbms.SQLDialectTest
  * @purpose  Base class for all dialects 
  */
-abstract class SQLDialect extends \lang\Object {
+abstract class SQLDialect {
   private static
     $dateparts= [
       'day'         => 'day',

--- a/src/main/php/rdbms/SQLFunction.class.php
+++ b/src/main/php/rdbms/SQLFunction.class.php
@@ -3,7 +3,7 @@
 /**
  * Represents an SQL standard procedure
  */
-class SQLFunction extends \lang\Object implements SQLFragment {
+class SQLFunction implements SQLFragment {
   public
     $func = '',
     $type = '%s',

--- a/src/main/php/rdbms/SQLFunctions.class.php
+++ b/src/main/php/rdbms/SQLFunctions.class.php
@@ -8,7 +8,7 @@ use lang\IllegalArgumentException;
  * @test  xp://net.xp_framework.unittest.rdbms.SQLFunctionTest
  * @see   xp://rdbms.Criteria
  */
-class SQLFunctions extends \lang\Object {
+class SQLFunctions {
 
   /**
    * return a substring from col1, that start at

--- a/src/main/php/rdbms/Statement.class.php
+++ b/src/main/php/rdbms/Statement.class.php
@@ -20,7 +20,7 @@
  *
  * @test  xp://net.xp_framework.unittest.rdbms.StatementTest
  */
-class Statement extends \lang\Object implements SQLExpression {
+class Statement implements SQLExpression {
   public $statement;
   public $arguments= [];
 

--- a/src/main/php/rdbms/StatementFormatter.class.php
+++ b/src/main/php/rdbms/StatementFormatter.class.php
@@ -15,7 +15,7 @@
  * @see   xp://rdbms.mysql.MysqlConnection
  * @see   xp://rdbms.pgsql.PostgresqlConnection
  */
-class StatementFormatter extends \lang\Object {
+class StatementFormatter {
   public $dialect= null;
   public $conn   = null;
 

--- a/src/main/php/rdbms/Transaction.class.php
+++ b/src/main/php/rdbms/Transaction.class.php
@@ -22,7 +22,7 @@
  * @see      xp://rdbms.DBConnection#begin
  * @purpose  Wrap a transaction
  */
-class Transaction extends \lang\Object {
+class Transaction {
   public
     $name     = '',
     $db       = null;

--- a/src/main/php/rdbms/criterion/BetweenExpression.class.php
+++ b/src/main/php/rdbms/criterion/BetweenExpression.class.php
@@ -3,7 +3,7 @@
 /**
  * Between expression
  */
-class BetweenExpression extends \lang\Object implements Criterion {
+class BetweenExpression implements Criterion {
   public
     $lhs    = '',
     $lo     = null,

--- a/src/main/php/rdbms/criterion/LogicalExpression.class.php
+++ b/src/main/php/rdbms/criterion/LogicalExpression.class.php
@@ -6,7 +6,7 @@ define('LOGICAL_OR',  'or');
 /**
  * Logical expression
  */
-class LogicalExpression extends \lang\Object implements Criterion {
+class LogicalExpression implements Criterion {
   public
     $criterions = [],
     $op         = '';

--- a/src/main/php/rdbms/criterion/NegationExpression.class.php
+++ b/src/main/php/rdbms/criterion/NegationExpression.class.php
@@ -3,7 +3,7 @@
 /**
  * Negates another criterion
  */
-class NegationExpression extends \lang\Object implements Criterion {
+class NegationExpression implements Criterion {
   public $criterion;
 
   /**

--- a/src/main/php/rdbms/criterion/ProjectionList.class.php
+++ b/src/main/php/rdbms/criterion/ProjectionList.class.php
@@ -33,7 +33,7 @@
  * @test  xp://net.xp_framework.unittest.rdbms.ProjectionListTest
  * @see   xp://rdbms.criterion.Projections
  */
-class ProjectionList extends \lang\Object implements Projection {
+class ProjectionList implements Projection {
   protected $projections= [];
 
   /**

--- a/src/main/php/rdbms/criterion/Projections.class.php
+++ b/src/main/php/rdbms/criterion/Projections.class.php
@@ -53,7 +53,7 @@
  * @see   xp://rdbms.criterion.ProjectionList
  * @see   xp://rdbms.criterion.CountProjection
  */
-class Projections extends \lang\Object {
+class Projections {
 
   /**
    * manufactor a new ProjectionList

--- a/src/main/php/rdbms/criterion/Property.class.php
+++ b/src/main/php/rdbms/criterion/Property.class.php
@@ -5,7 +5,7 @@
  *
  * @deprecated use rdbms.Column instead
  */
-class Property extends \lang\Object {
+class Property {
   protected static $instances= [];
   public $name;
 

--- a/src/main/php/rdbms/criterion/Restrictions.class.php
+++ b/src/main/php/rdbms/criterion/Restrictions.class.php
@@ -5,7 +5,7 @@
  *
  * @test  xp://net.xp_framework.unittest.rdbms.CriteriaTest
  */
-class Restrictions extends \lang\Object {
+class Restrictions {
 
   /**
    * Apply an "in" constraint to the named property

--- a/src/main/php/rdbms/criterion/SimpleExpression.class.php
+++ b/src/main/php/rdbms/criterion/SimpleExpression.class.php
@@ -7,7 +7,7 @@ use rdbms\SQLFragment;
 /**
  * Simple expression
  */
-class SimpleExpression extends \lang\Object implements Criterion {
+class SimpleExpression implements Criterion {
   public
     $lhs    = null,
     $value  = null,

--- a/src/main/php/rdbms/criterion/SimpleProjection.class.php
+++ b/src/main/php/rdbms/criterion/SimpleProjection.class.php
@@ -11,7 +11,7 @@ use rdbms\DBConnection;
  * @see   xp://rdbms.criterion.CountProjection
  * @see   xp://rdbms.criterion.ProjectionList
  */
-class SimpleProjection extends \lang\Object implements Projection {
+class SimpleProjection implements Projection {
   protected $field, $command;
 
   /**

--- a/src/main/php/rdbms/finder/Finder.class.php
+++ b/src/main/php/rdbms/finder/Finder.class.php
@@ -63,7 +63,7 @@ use lang\MethodNotImplementedException;
  * @test     xp://net.xp_framework.unittest.rdbms.FinderTest
  * @purpose  Base class for all finder
  */
-abstract class Finder extends \lang\Object {
+abstract class Finder {
 
   /**
    * Returns the associated peer objects
@@ -80,7 +80,7 @@ abstract class Finder extends \lang\Object {
    */
   protected function finderMethods($kind) {
     $r= [];
-    foreach ($this->getClass()->getMethods() as $m) {
+    foreach (typeof($this)->getMethods() as $m) {
       if (
         $m->hasAnnotation('finder') &&
         (null === $kind || $kind == $m->getAnnotation('finder', 'kind'))
@@ -130,7 +130,7 @@ abstract class Finder extends \lang\Object {
     null === $name && $name= 'all';
 
     try {
-      $m= $this->getClass()->getMethod($name);
+      $m= typeof($this)->getMethod($name);
     } catch (\lang\ElementNotFoundException $e) {
       throw new FinderException('No such finder', new MethodNotImplementedException('Cannot find finder method', $name));
     }

--- a/src/main/php/rdbms/finder/FinderDelegate.class.php
+++ b/src/main/php/rdbms/finder/FinderDelegate.class.php
@@ -4,7 +4,7 @@
  * Abstract base class for finder delegates
  *
  */
-abstract class FinderDelegate extends \lang\Object {
+abstract class FinderDelegate {
   protected $finder= null;
 
   /**

--- a/src/main/php/rdbms/finder/FinderMethod.class.php
+++ b/src/main/php/rdbms/finder/FinderMethod.class.php
@@ -14,7 +14,7 @@
  * @see      xp://rdbms.finder.Finder
  * @purpose  Method wrapper
  */
-class FinderMethod extends \lang\Object {
+class FinderMethod {
   protected
     $finder= null, 
     $method= null;

--- a/src/main/php/rdbms/join/Fetchmode.class.php
+++ b/src/main/php/rdbms/join/Fetchmode.class.php
@@ -9,7 +9,7 @@
  * @purpose rdbms.join
  * @see     xp://rdbms.Criteria#setFetchmode
  */
-class Fetchmode extends \lang\Object {
+class Fetchmode {
   private
     $path= '',
     $mode= '';

--- a/src/main/php/rdbms/join/JoinIterator.class.php
+++ b/src/main/php/rdbms/join/JoinIterator.class.php
@@ -7,7 +7,7 @@
  * @see   xp://rdbms.Criteria#getSelectQueryString
  * @see   xp://rdbms.Peer#iteratorFor
  */
-class JoinIterator extends \lang\Object implements \util\XPIterator, JoinExtractable {
+class JoinIterator implements \util\XPIterator, JoinExtractable {
   private
     $resultObj= null,
     $record= [],

--- a/src/main/php/rdbms/join/JoinPart.class.php
+++ b/src/main/php/rdbms/join/JoinPart.class.php
@@ -15,7 +15,7 @@ use util\collections\HashTable;
  * @see     xp://rdbms.join.JoinTableAttributes
  * @purpose rdbms.join
  */
-class JoinPart extends \lang\Object {
+class JoinPart {
   public
     $peer=      null;
 

--- a/src/main/php/rdbms/join/JoinProcessor.class.php
+++ b/src/main/php/rdbms/join/JoinProcessor.class.php
@@ -9,7 +9,7 @@
  * @test    xp://net.xp_framework.unittest.rdbms.JoinProcessorTest
  * @see     xp://rdbms.join.Fetchmode
  */
-class JoinProcessor extends \lang\Object {
+class JoinProcessor {
   const SEPARATOR= '->';
   const FIRST= 'start';
 

--- a/src/main/php/rdbms/join/JoinRelation.class.php
+++ b/src/main/php/rdbms/join/JoinRelation.class.php
@@ -10,7 +10,7 @@
  * @purpose rdbms.join
  *
  */
-class JoinRelation extends \lang\Object {
+class JoinRelation {
   private
     $source= null,
     $target= null,

--- a/src/main/php/rdbms/join/JoinTable.class.php
+++ b/src/main/php/rdbms/join/JoinTable.class.php
@@ -7,7 +7,7 @@
  * @purpose rdbms.join
  * @see     xp://rdbms.join.JoinPart
  */
-class JoinTable extends \lang\Object {
+class JoinTable {
   private
     $alias= '',
     $name=  '';

--- a/src/main/php/rdbms/join/JoinTableAttribute.class.php
+++ b/src/main/php/rdbms/join/JoinTableAttribute.class.php
@@ -7,7 +7,7 @@
  * @see     xp://rdbms.join.JoinPart
  * @purpose rdbms.join
  */
-class JoinTableAttribute extends \lang\Object {
+class JoinTableAttribute {
   private
     $alias= '',
     $name= '',

--- a/src/main/php/rdbms/mysqlx/LocalSocket.class.php
+++ b/src/main/php/rdbms/mysqlx/LocalSocket.class.php
@@ -14,7 +14,7 @@ use io\File;
  *
  * @see     http://dev.mysql.com/doc/refman/5.1/en/option-files.html
  */
-abstract class LocalSocket extends \lang\Object {
+abstract class LocalSocket {
 
   /**
    * Returns the implementation for the given operating system.

--- a/src/main/php/rdbms/mysqlx/MySqlxProtocol.class.php
+++ b/src/main/php/rdbms/mysqlx/MySqlxProtocol.class.php
@@ -9,7 +9,7 @@ use util\Date;
  *
  * @see   http://forge.mysql.com/wiki/MySQL_Internals_ClientServer_Protocol
  */
-class MySqlxProtocol extends \lang\Object {
+class MySqlxProtocol {
   protected $pkt= 0, $thread= 0;
   protected $sock= null;
   public $connected= false;

--- a/src/main/php/rdbms/query/Query.class.php
+++ b/src/main/php/rdbms/query/Query.class.php
@@ -25,7 +25,7 @@ use rdbms\Criteria;
  * @see      xp://rdbms.query.UpdateQuery
  * @purpose  Base class for SelectQuery, DeleteQuery and UpdateQuery
  */
-abstract class Query extends \lang\Object implements QueryExecutable {
+abstract class Query implements QueryExecutable {
   protected
     $criteria=     null,
     $peer=         null;

--- a/src/main/php/rdbms/query/SetOperation.class.php
+++ b/src/main/php/rdbms/query/SetOperation.class.php
@@ -50,7 +50,7 @@ use rdbms\Record;
  * @see      xp://rdbms.query.Query
  * @purpose  rdbms.query
  */
-class SetOperation extends \lang\Object implements SelectQueryExecutable {
+class SetOperation implements SelectQueryExecutable {
   const UNION=         'union';
   const UNION_ALL=     'union_all';
   const INTERCEPT=     'intercept';

--- a/src/main/php/rdbms/sybase/SybaseIOObserver.class.php
+++ b/src/main/php/rdbms/sybase/SybaseIOObserver.class.php
@@ -10,7 +10,7 @@ use rdbms\DBEvent;
  * @ext      sybase
  * @purpose  Observe SybaseConnection
  */
-class SybaseIOObserver extends \lang\Object implements BoundLogObserver {
+class SybaseIOObserver implements BoundLogObserver {
   protected
     $messages = [],
     $queries  = [];

--- a/src/main/php/rdbms/sybase/SybaseShowplanObserver.class.php
+++ b/src/main/php/rdbms/sybase/SybaseShowplanObserver.class.php
@@ -11,7 +11,7 @@ use rdbms\DBEvent;
  * @ext      sybase
  * @purpose  Observe SybaseConnection
  */
-class SybaseShowplanObserver extends \lang\Object implements \util\log\BoundLogObserver {
+class SybaseShowplanObserver implements \util\log\BoundLogObserver {
   protected
     $messages     = [],
     $queries      = [];

--- a/src/main/php/rdbms/tds/FreeTdsLookup.class.php
+++ b/src/main/php/rdbms/tds/FreeTdsLookup.class.php
@@ -8,7 +8,7 @@ use io\File;
  * @test    xp://net.xp_framework.unittest.rdbms.tds.FreeTdsLookupTest
  * @test    xp://net.xp_framework.unittest.rdbms.tds.FreeTdsConfigLocationTest
  */
-class FreeTdsLookup extends \lang\Object implements ConnectionLookup {
+class FreeTdsLookup implements ConnectionLookup {
   protected $conf= null;
   
   /**

--- a/src/main/php/rdbms/tds/InterfacesLookup.class.php
+++ b/src/main/php/rdbms/tds/InterfacesLookup.class.php
@@ -7,7 +7,7 @@ use io\File;
  *
  * @test    xp://net.xp_framework.unittest.rdbms.tds.InterfacesLookupTest
  */
-class InterfacesLookup extends \lang\Object implements ConnectionLookup {
+class InterfacesLookup implements ConnectionLookup {
   protected $file= null;
   
   /**

--- a/src/main/php/rdbms/tds/SqlIniLookup.class.php
+++ b/src/main/php/rdbms/tds/SqlIniLookup.class.php
@@ -7,7 +7,7 @@ use io\File;
  *
  * @test    xp://net.xp_framework.unittest.rdbms.tds.SqlIniLookupTest
  */
-class SqlIniLookup extends \lang\Object implements ConnectionLookup {
+class SqlIniLookup implements ConnectionLookup {
   protected $ini= null;
   
   /**

--- a/src/main/php/rdbms/tds/TdsDataStream.class.php
+++ b/src/main/php/rdbms/tds/TdsDataStream.class.php
@@ -8,7 +8,7 @@ use lang\IllegalArgumentException;
  * @see     xp://rdbms.tds.TdsV7Protocolo#read
  * @test    xp://net.xp_framework.unittest.rdbms.tds.TdsDataStreamTest
  */
-class TdsDataStream extends \lang\Object {
+class TdsDataStream {
   protected $pkt= 0;
   protected $packetSize= 0;
   protected $sock= null;

--- a/src/main/php/rdbms/tds/TdsProtocol.class.php
+++ b/src/main/php/rdbms/tds/TdsProtocol.class.php
@@ -11,7 +11,7 @@ use peer\ProtocolException;
  * @see   http://www.freetds.org/tds.html
  * @see   https://github.com/mono/mono/tree/master/mcs/class/Mono.Data.Tds/Mono.Data.Tds.Protocol
  */
-abstract class TdsProtocol extends \lang\Object {
+abstract class TdsProtocol {
   protected $servercs= 'cp850';
   protected $stream= null;
   protected $done= false;

--- a/src/main/php/rdbms/tds/TdsRecord.class.php
+++ b/src/main/php/rdbms/tds/TdsRecord.class.php
@@ -5,7 +5,7 @@ use util\Date;
 /**
  * Abstract base class for TDS records
  */
-abstract class TdsRecord extends \lang\Object {
+abstract class TdsRecord {
   protected static $precision;
 
   static function __static() {

--- a/src/main/php/rdbms/util/DBConstraintXmlGenerator.class.php
+++ b/src/main/php/rdbms/util/DBConstraintXmlGenerator.class.php
@@ -11,7 +11,7 @@ use xml\Tree;
  *
  * @see   xp://rdbms.DBTable
  */
-class DBConstraintXmlGenerator extends \lang\Object implements Traceable {
+class DBConstraintXmlGenerator implements Traceable {
   protected
     $cat= null,
     $tables= null;

--- a/src/main/php/rdbms/util/DBXMLNamingContext.class.php
+++ b/src/main/php/rdbms/util/DBXMLNamingContext.class.php
@@ -5,7 +5,7 @@
  * Generate Names for database generated classes
  *
  */
-class DBXMLNamingContext extends \lang\Object {
+class DBXMLNamingContext {
 
   private static $strategy= null;
   

--- a/src/main/php/rdbms/util/DBXMLNamingStrategy.class.php
+++ b/src/main/php/rdbms/util/DBXMLNamingStrategy.class.php
@@ -4,7 +4,7 @@
  * Generate Names for database generated classes
  *
  */
-abstract class DBXMLNamingStrategy extends \lang\Object {
+abstract class DBXMLNamingStrategy {
   
   /**
    * assemble th name of a foreign key constraint

--- a/src/main/php/rdbms/util/DBXmlGenerator.class.php
+++ b/src/main/php/rdbms/util/DBXmlGenerator.class.php
@@ -10,7 +10,7 @@ use util\log\Traceable;
  *
  * @see   xp://rdbms.DBTable
  */
-class DBXmlGenerator extends \lang\Object implements Traceable {
+class DBXmlGenerator implements Traceable {
   protected
     $cat= null;
 

--- a/src/test/php/rdbms/unittest/DriverManagerTest.class.php
+++ b/src/test/php/rdbms/unittest/DriverManagerTest.class.php
@@ -85,7 +85,7 @@ class DriverManagerTest extends \unittest\TestCase {
 
   #[@test, @expect(IllegalArgumentException::class)]
   public function registerNonDbConnection() {
-    $this->register('fail', $this->getClass());
+    $this->register('fail', typeof($this));
   }
 
   #[@test]

--- a/src/test/php/rdbms/unittest/integration/SQLRunner.class.php
+++ b/src/test/php/rdbms/unittest/integration/SQLRunner.class.php
@@ -8,7 +8,7 @@ use util\cmd\Console;
  *
  * @see   xp://net.xp_framework.unittest.rdbms.integration.AbstractDeadlockTest
  */
-class SQLRunner extends \lang\Object {
+class SQLRunner {
   
   /**
    * Entry point

--- a/src/test/php/rdbms/unittest/integration/SybaseIntegrationTest.class.php
+++ b/src/test/php/rdbms/unittest/integration/SybaseIntegrationTest.class.php
@@ -33,7 +33,7 @@ class SybaseIntegrationTest extends RdbmsIntegrationTest {
    */
   public function setUp() {
     parent::setUp();
-    $m= $this->getClass()->getMethod($this->name);
+    $m= typeof($this)->getMethod($this->name);
     if ($m->hasAnnotation('version')) {
       $server= $this->db()->query('select @@version_number as v')->next('v');
       if ($server < ($required= $m->getAnnotation('version'))) {

--- a/src/test/php/rdbms/unittest/mock/RegisterMockConnection.class.php
+++ b/src/test/php/rdbms/unittest/mock/RegisterMockConnection.class.php
@@ -5,7 +5,7 @@
  *
  * @see   xp://net.xp_framework.unittest.rdbms.mock.MockConnection
  */
-class RegisterMockConnection extends \lang\Object implements \unittest\TestClassAction {
+class RegisterMockConnection implements \unittest\TestClassAction {
   const MOCK_CONNECTION_CLASS = 'rdbms.unittest.mock.MockConnection';
 
   /**

--- a/src/test/php/rdbms/unittest/tds/FreeTdsLookupTest.class.php
+++ b/src/test/php/rdbms/unittest/tds/FreeTdsLookupTest.class.php
@@ -15,7 +15,7 @@ class FreeTdsLookupTest extends \unittest\TestCase {
    * Sets up test case
    */
   public function setUp() {
-    $this->fixture= new FreeTdsLookup($this->getClass()->getPackage()->getResourceAsStream('freetds.conf'));
+    $this->fixture= new FreeTdsLookup(typeof($this)->getPackage()->getResourceAsStream('freetds.conf'));
   }
   
   #[@test]

--- a/src/test/php/rdbms/unittest/tds/InterfacesLookupTest.class.php
+++ b/src/test/php/rdbms/unittest/tds/InterfacesLookupTest.class.php
@@ -15,7 +15,7 @@ class InterfacesLookupTest extends \unittest\TestCase {
    * Sets up test case
    */
   public function setUp() {
-    $this->fixture= new InterfacesLookup($this->getClass()->getPackage()->getResourceAsStream('interfaces'));
+    $this->fixture= new InterfacesLookup(typeof($this)->getPackage()->getResourceAsStream('interfaces'));
   }
   
   #[@test]

--- a/src/test/php/rdbms/unittest/tds/SqlIniLookupTest.class.php
+++ b/src/test/php/rdbms/unittest/tds/SqlIniLookupTest.class.php
@@ -15,7 +15,7 @@ class SqlIniLookupTest extends \unittest\TestCase {
    * Sets up test case
    */
   public function setUp() {
-    $this->fixture= new SqlIniLookup($this->getClass()->getPackage()->getResourceAsStream('sql.ini'));
+    $this->fixture= new SqlIniLookup(typeof($this)->getPackage()->getResourceAsStream('sql.ini'));
   }
   
   #[@test]

--- a/src/test/php/rdbms/unittest/tds/TdsDataStreamTest.class.php
+++ b/src/test/php/rdbms/unittest/tds/TdsDataStreamTest.class.php
@@ -69,7 +69,7 @@ class TdsDataStreamTest extends \unittest\TestCase {
    * @throws  unittest.AssertionFailedError
    */
   protected function assertBytes($bytes, $str) {
-    $field= $str->getClass()->getField('sock')->setAccessible(true);
+    $field= typeof($str)->getField('sock')->setAccessible(true);
     $this->assertEquals(new Bytes($bytes), new Bytes($field->get($str)->bytes));
   }
 


### PR DESCRIPTION
This pull request makes the unittest library compatible with XP9:

* Removes `lang.Object` references, replacing them with dedicated value objects
* Implements `lang.Value` where toString() / hashCode() / comparison are necessary
* Adds versions of dependencies compatible w/ XP9.0 to composer.json