### PR TITLE
SQL Subcommand

### DIFF
--- a/bin/xp.xp-framework.rdbms.sql
+++ b/bin/xp.xp-framework.rdbms.sql
@@ -1,0 +1,2 @@
+#!/usr/bin/env php
+This must be run from within an XP runner

--- a/src/main/php/rdbms/DefaultDrivers.class.php
+++ b/src/main/php/rdbms/DefaultDrivers.class.php
@@ -47,6 +47,9 @@ class DefaultDrivers extends DriverImplementationsProvider {
     self::$impl['ibase']= ['rdbms.ibase.InterBaseConnection'];
   }
 
+  /** @return string[] */
+  public function drivers() { return array_keys(self::$impl); }
+
   /**
    * Returns an array of class names implementing a given driver
    *

--- a/src/main/php/rdbms/DriverImplementationsProvider.class.php
+++ b/src/main/php/rdbms/DriverImplementationsProvider.class.php
@@ -26,7 +26,10 @@ abstract class DriverImplementationsProvider {
   public function implementationsFor($driver) {
     return null === $this->parent ? [] : $this->parent->implementationsFor($driver);
   }
-  
+
+  /** @return string[] */
+  public function drivers() { return []; }
+
   /**
    * Creates a string representation of this implementation provider
    *

--- a/src/main/php/rdbms/DriverImplementationsProvider.class.php
+++ b/src/main/php/rdbms/DriverImplementationsProvider.class.php
@@ -28,7 +28,9 @@ abstract class DriverImplementationsProvider {
   }
 
   /** @return string[] */
-  public function drivers() { return []; }
+  public function drivers() {
+    return null === $this->parent ? [] : $this->parent->drivers();
+  }
 
   /**
    * Creates a string representation of this implementation provider

--- a/src/main/php/rdbms/mysql/MySQLConnection.class.php
+++ b/src/main/php/rdbms/mysql/MySQLConnection.class.php
@@ -6,7 +6,7 @@ use rdbms\StatementFormatter;
 use rdbms\QuerySucceeded;
 
 /**
- * Connection to MySQL Databases
+ * Connection to MySQL Databases via ext/mysql
  *
  * @see      http://mysql.org/
  * @ext      mysql

--- a/src/main/php/rdbms/pgsql/PostgreSQLConnection.class.php
+++ b/src/main/php/rdbms/pgsql/PostgreSQLConnection.class.php
@@ -6,7 +6,7 @@ use rdbms\StatementFormatter;
 use rdbms\QuerySucceeded;
 
 /**
- * Connection to PostgreSQL Databases
+ * Connection to PostgreSQL Databases via ext/pgsql
  *
  * @see      http://www.postgresql.org/
  * @see      http://www.freebsddiary.org/postgresql.php

--- a/src/main/php/rdbms/sqlite3/SQLite3Connection.class.php
+++ b/src/main/php/rdbms/sqlite3/SQLite3Connection.class.php
@@ -6,8 +6,10 @@ use rdbms\StatementFormatter;
 use rdbms\QuerySucceeded;
 
 /**
- * Connection to SQLite Databases; specify the path to the database
- * file as the DSN's path - the hostname property should remain empty.
+ * Connection to SQLite 3.x Databases via ext/sqlite3
+ *
+ * Specify the path to the database file as the DSN's path - the
+ * hostname property should remain empty.
  *
  * To use in-memory databases, use :memory: as path - remember to
  * urlencode its value.
@@ -41,7 +43,7 @@ use rdbms\QuerySucceeded;
  *   changedby    string
  * </pre>
  *
- * @ext      sqlite
+ * @ext      sqlite3
  * @see      http://sqlite.org/
  * @see      http://php.net/sqlite3
  * @test     xp://net.xp_framework.unittest.rdbms.sqlite3.SQLite3ConnectionTest

--- a/src/main/php/rdbms/sybase/SybaseConnection.class.php
+++ b/src/main/php/rdbms/sybase/SybaseConnection.class.php
@@ -6,7 +6,7 @@ use rdbms\StatementFormatter;
 use rdbms\QuerySucceeded;
 
 /**
- * Connection to Sybase databases using client libraries
+ * Connection to Sybase databases using client libraries (sybase_ct)
  *
  * @see    http://sybase.com/
  * @ext    sybase_ct

--- a/src/main/php/xp/rdbms/SqlRunner.class.php
+++ b/src/main/php/xp/rdbms/SqlRunner.class.php
@@ -1,6 +1,7 @@
 <?php namespace xp\rdbms;
 
 use rdbms\DriverManager;
+use rdbms\SQLException;
 use rdbms\DefaultDrivers;
 use util\profiling\Timer;
 use util\cmd\Console;
@@ -30,7 +31,7 @@ class SqlRunner {
    * @param  rdbms.DriverImplementationsProvider $provider
    * @return int
    */
-  private function drivers($provider) {
+  private static function drivers($provider) {
     Console::writeLine("\e[33m@", nameof($provider), "\e[0m");
     Console::writeLine("\e[1mAvailable drivers\e[0m");
     Console::writeLine(str_repeat('═', 72));
@@ -61,7 +62,7 @@ class SqlRunner {
    * @param  string $dsn
    * @return int
    */
-  private function interactive($dsn) {
+  private static function interactive($dsn) {
     Console::$err->writeLine('Not yet implemented');
     return 255;
   }
@@ -73,7 +74,7 @@ class SqlRunner {
    * @param  string... $statements
    * @return int
    */
-  private function execute($dsn, ...$statements) {
+  private static function execute($dsn, ...$statements) {
     $conn= DriverManager::getConnection($dsn);
     $timer= new Timer();
 

--- a/src/main/php/xp/rdbms/SqlRunner.class.php
+++ b/src/main/php/xp/rdbms/SqlRunner.class.php
@@ -64,8 +64,8 @@ class SqlRunner {
    * @return int
    */
   private static function drivers($provider) {
-    Console::writeLine("\e[33m@", nameof($provider), "\e[0m");
-    Console::writeLine("\e[1mAvailable drivers\e[0m");
+    Console::writeLine("\e[33m@", typeof($provider)->getClassLoader(), "\e[0m");
+    Console::writeLine("\e[1mAvailable drivers via ", nameof($provider), "\e[0m");
     Console::writeLine(str_repeat('═', 72));
     Console::writeLine();
 

--- a/src/main/php/xp/rdbms/SqlRunner.class.php
+++ b/src/main/php/xp/rdbms/SqlRunner.class.php
@@ -1,0 +1,14 @@
+<?php namespace xp\rdbms;
+
+class SqlRunner {
+
+  /**
+   * Runs SQL
+   *
+   * @param  string[] $args
+   * @return int exitcode
+   */
+  public static function main(array $args) {
+    return 0;
+  }
+}

--- a/src/main/php/xp/rdbms/SqlRunner.class.php
+++ b/src/main/php/xp/rdbms/SqlRunner.class.php
@@ -1,9 +1,11 @@
 <?php namespace xp\rdbms;
 
 use rdbms\DriverManager;
+use rdbms\DefaultDrivers;
 use util\profiling\Timer;
 use util\cmd\Console;
 use io\streams\Streams;
+use lang\XPClass;
 
 /**
  * Runs SQL statements
@@ -17,8 +19,91 @@ use io\streams\Streams;
  *   ```sh
  *   $ cat statement.sql | xp sql 'sqlite://./test.db' -
  *   ```
+ *
+ * Invoking without arguments shows a list of available drivers.
  */
 class SqlRunner {
+
+  /**
+   * Shows drivers
+   *
+   * @param  rdbms.DriverImplementationsProvider $provider
+   * @return int
+   */
+  private function drivers($provider) {
+    Console::writeLine("\e[33m@", nameof($provider), "\e[0m");
+    Console::writeLine("\e[1mAvailable drivers\e[0m");
+    Console::writeLine(str_repeat('═', 72));
+    Console::writeLine();
+
+    // Load all implementations
+    foreach ($provider->drivers() as $driver) {
+      foreach ($provider->implementationsFor($driver) as $impl) {
+        XPClass::forName($impl);
+      }
+    }
+
+    // Iterate over registered
+    $registered= DriverManager::getInstance();
+    foreach ($registered->drivers as $driver => $impl) {
+      Console::writeLine("\e[33;1m>\e[0m \e[35;1m", $driver, "\e[0m: ", $impl->getName());
+
+      $comment= $impl->getComment();
+      Console::writeLine('  ', substr($comment, 0, strcspn($comment, "\n")));
+      Console::writeLine();
+    }
+    return 0;
+  }
+
+  /**
+   * Starts an interactive SQL shell
+   *
+   * @param  string $dsn
+   * @return int
+   */
+  private function interactive($dsn) {
+    Console::$err->writeLine('Not yet implemented');
+    return 255;
+  }
+
+  /**
+   * Executes SQL statements; stops on first statement causing an error.
+   *
+   * @param  string $dsn
+   * @param  string... $statements
+   * @return int
+   */
+  private function execute($dsn, ...$statements) {
+    $conn= DriverManager::getConnection($dsn);
+    $timer= new Timer();
+
+    foreach ($statements as $statement) {
+      if ('-' === $statement) {
+        $sql= Streams::readAll(Console::$in->getStream());
+      } else {
+        $sql= $statement;
+      }
+
+      try {
+        $q= $conn->query($sql);
+        if ($q->isSuccess()) {
+          Console::$err->writeLinef('Query OK, %d rows affected (%.2f sec)', $q->affected(), $timer->elapsedTime());
+        } else {
+          $rows= 0;
+          while ($record= $q->next()) {
+            Console::writeLine($record);
+            $rows++;
+          }
+          Console::$err->writeLinef('%d rows in set (%.2f sec)', $rows, $timer->elapsedTime());
+        }
+        $q->close();
+      } catch (SQLException $e) {
+        Console::$err->writeLine("\e[31m*** ", $e->compoundMessage(), "\e[0m");
+        return 1;
+      }
+    }
+    return 0;
+  }
 
   /**
    * Runs SQL
@@ -27,33 +112,10 @@ class SqlRunner {
    * @return int exitcode
    */
   public static function main(array $args) {
-    $dsn= $args[0];
-
-    // SQL query. Use `-` to read from standard input.
-    if ('-' === $args[1]) {
-      $sql= Streams::readAll(Console::$in->getStream());
-    } else {
-      $sql= $args[1];
+    switch (sizeof($args)) {
+      case 0: return self::drivers(new DefaultDrivers());
+      case 1: return self::interactive($args[0]);
+      default: return self::execute($args[0], array_slice($args, 1));
     }
-
-    $conn= DriverManager::getConnection($dsn);
-    $timer= (new Timer())->start();
-    try {
-      $q= $conn->query($sql);
-      if ($q->isSuccess()) {
-        Console::$err->writeLinef('Query OK, %d rows affected (%.2f sec)', $q->affected(), $timer->elapsedTime());
-      } else {
-        $rows= 0;
-        while ($record= $q->next()) {
-          Console::writeLine($record);
-          $rows++;
-        }
-        Console::$err->writeLinef('%d rows in set (%.2f sec)', $rows, $timer->elapsedTime());
-      }
-      $q->close();
-    } catch (SQLException $e) {
-      Console::$err->writeLine("\e[31m*** ", $e->compoundMessage(), "\e[0m");
-    }
-    return 0;
   }
 }

--- a/src/main/php/xp/rdbms/SqlRunner.class.php
+++ b/src/main/php/xp/rdbms/SqlRunner.class.php
@@ -130,14 +130,14 @@ class SqlRunner {
         $timer->start();
         $q= $conn->query($sql);
         if ($q->isSuccess()) {
-          Console::$err->writeLinef('Query OK, %d rows affected (%.2f sec)', $q->affected(), $timer->elapsedTime());
+          Console::$err->writeLinef('Query OK, %d row(s) affected (%.2f sec)', $q->affected(), $timer->elapsedTime());
         } else {
           $rows= 0;
           while ($record= $q->next()) {
             Console::writeLine(self::$display[$mode]($record));
             $rows++;
           }
-          Console::$err->writeLinef('%d rows in set (%.2f sec)', $rows, $timer->elapsedTime());
+          Console::$err->writeLinef('%d row(s) in set (%.2f sec)', $rows, $timer->elapsedTime());
         }
         $q->close();
       } catch (SQLException $e) {

--- a/src/main/php/xp/rdbms/SqlRunner.class.php
+++ b/src/main/php/xp/rdbms/SqlRunner.class.php
@@ -4,6 +4,15 @@ use rdbms\DriverManager;
 use util\profiling\Timer;
 use util\cmd\Console;
 
+/**
+ * Runs SQL statements
+ * ========================================================================
+ *
+ * - Execute a single SQL statement and print the results
+ *   ```sh
+ *   $ xp sql 'sqlite://./test.db' 'select * from test'
+ *   ```
+ */
 class SqlRunner {
 
   /**

--- a/src/main/php/xp/rdbms/SqlRunner.class.php
+++ b/src/main/php/xp/rdbms/SqlRunner.class.php
@@ -71,10 +71,10 @@ class SqlRunner {
    * Executes SQL statements; stops on first statement causing an error.
    *
    * @param  string $dsn
-   * @param  string... $statements
+   * @param  string[] $statements
    * @return int
    */
-  private static function execute($dsn, ...$statements) {
+  private static function execute($dsn, $statements) {
     $conn= DriverManager::getConnection($dsn);
     $timer= new Timer();
 
@@ -86,6 +86,7 @@ class SqlRunner {
       }
 
       try {
+        $timer->start();
         $q= $conn->query($sql);
         if ($q->isSuccess()) {
           Console::$err->writeLinef('Query OK, %d rows affected (%.2f sec)', $q->affected(), $timer->elapsedTime());

--- a/src/main/php/xp/rdbms/SqlRunner.class.php
+++ b/src/main/php/xp/rdbms/SqlRunner.class.php
@@ -1,5 +1,9 @@
 <?php namespace xp\rdbms;
 
+use rdbms\DriverManager;
+use util\profiling\Timer;
+use util\cmd\Console;
+
 class SqlRunner {
 
   /**
@@ -9,6 +13,28 @@ class SqlRunner {
    * @return int exitcode
    */
   public static function main(array $args) {
+    $dsn= $args[0];
+    $sql= $args[1];
+
+    $conn= DriverManager::getConnection($dsn);
+    $timer= (new Timer())->start();
+    try {
+      $q= $conn->query($sql);
+      if ($q->isSuccess()) {
+        Console::writeLinef('Query OK, %d rows affected (%.2f sec)', $q->affected(), $timer->elapsedTime());
+      } else {
+        $rows= 0;
+        while ($record= $q->next()) {
+          Console::writeLine($record);
+          $rows++;
+        }
+        Console::writeLinef('%d rows in set (%.2f sec)', $rows, $timer->elapsedTime());
+      }
+      $q->close();
+      Console::writeLine();
+    } catch (SQLException $e) {
+      Console::writeLine("\e[31m*** ", $e->compoundMessage(), "\e[0m");
+    }
     return 0;
   }
 }

--- a/src/main/php/xp/rdbms/SqlRunner.class.php
+++ b/src/main/php/xp/rdbms/SqlRunner.class.php
@@ -30,19 +30,18 @@ class SqlRunner {
     try {
       $q= $conn->query($sql);
       if ($q->isSuccess()) {
-        Console::writeLinef('Query OK, %d rows affected (%.2f sec)', $q->affected(), $timer->elapsedTime());
+        Console::$err->writeLinef('Query OK, %d rows affected (%.2f sec)', $q->affected(), $timer->elapsedTime());
       } else {
         $rows= 0;
         while ($record= $q->next()) {
           Console::writeLine($record);
           $rows++;
         }
-        Console::writeLinef('%d rows in set (%.2f sec)', $rows, $timer->elapsedTime());
+        Console::$err->writeLinef('%d rows in set (%.2f sec)', $rows, $timer->elapsedTime());
       }
       $q->close();
-      Console::writeLine();
     } catch (SQLException $e) {
-      Console::writeLine("\e[31m*** ", $e->compoundMessage(), "\e[0m");
+      Console::$err->writeLine("\e[31m*** ", $e->compoundMessage(), "\e[0m");
     }
     return 0;
   }

--- a/src/main/php/xp/rdbms/SqlRunner.class.php
+++ b/src/main/php/xp/rdbms/SqlRunner.class.php
@@ -3,6 +3,7 @@
 use rdbms\DriverManager;
 use util\profiling\Timer;
 use util\cmd\Console;
+use io\streams\Streams;
 
 /**
  * Runs SQL statements
@@ -11,6 +12,10 @@ use util\cmd\Console;
  * - Execute a single SQL statement and print the results
  *   ```sh
  *   $ xp sql 'sqlite://./test.db' 'select * from test'
+ *   ```
+ * - Read SQL statement from standard input using "-"
+ *   ```sh
+ *   $ cat statement.sql | xp sql 'sqlite://./test.db' -
  *   ```
  */
 class SqlRunner {
@@ -23,7 +28,13 @@ class SqlRunner {
    */
   public static function main(array $args) {
     $dsn= $args[0];
-    $sql= $args[1];
+
+    // SQL query. Use `-` to read from standard input.
+    if ('-' === $args[1]) {
+      $sql= Streams::readAll(Console::$in->getStream());
+    } else {
+      $sql= $args[1];
+    }
 
     $conn= DriverManager::getConnection($dsn);
     $timer= (new Timer())->start();


### PR DESCRIPTION
Implements #33, however, not with an *interactive* shell, rather a command line query execution tool.

## Usage
```bash
$ xp help sql
@FileSystemCL<./src/main/php>
Runs SQL statements
════════════════════════════════════════════════════════════════════════

> Execute a single SQL statement and print the results

  $ xp sql 'sqlite://./test.db' 'select * from test'

> Change output mode by appending -m and one of csv, vert

  $ xp sql 'sqlite://./test.db' 'select * from test;-m csv'

> Read SQL statement from standard input using "-"

  $ cat statement.sql | xp sql 'sqlite://./test.db' -


Invoking without arguments shows a list of available drivers.
```
*The `-m [vert,csv]` syntax is inspired by SQSH, see http://manpages.ubuntu.com/manpages/precise/man1/sqsh.1.html*

## Drivers

```bash
$ xp sql
@FileSystemCL<./src/main/php>
Available drivers via rdbms.DefaultDrivers
════════════════════════════════════════════════════════════════════════

> mysql+x: rdbms.mysqlx.MySqlxConnection
  Connection to MySQL Databases

> mysql+std: rdbms.mysql.MySQLConnection
  Connection to MySQL Databases via ext/mysql

> sybase+x: rdbms.tds.SybasexConnection
  Connection to Sybase Databases via TDS 5.0

> mssql+x: rdbms.tds.MsSQLxConnection
  Connection to MSSQL Databases via TDS 7.0

> sqlite+3: rdbms.sqlite3.SQLite3Connection
  Connection to SQLite 3.x Databases via ext/sqlite3
```

## Examples

```bash
$ xp sql 'sqlite://./test.db' 'create table test (
  id integer primary key autoincrement,
  name varchar
)'
Query OK, 0 rows affected (0.02 sec)

$ xp sql 'sqlite://./test.db' 'insert into test (name) values ("Timm")'
Query OK, 1 rows affected (0.02 sec)

$ xp sql 'sqlite://./test.db' 'select * from test where id = 1'
id: 1
name: "Timm"

1 rows in set (0.00 sec)
```