### PR TITLE
Persistent connections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false
 
 services:
   - mysql
-  - postgresql
+  # - postgresql
 
 php:
   - 5.6
@@ -22,7 +22,7 @@ matrix:
 
 before_install:
   - mysql -e 'create database IF NOT EXISTS test;' -uroot
-  - psql -c 'create database travis_ci_test;' -U postgres
+  # - psql -c 'create database travis_ci_test;' -U postgres
 
 before_script:
   - curl -sSL https://dl.bintray.com/xp-runners/generic/xp-run-master.sh > xp-run
@@ -31,7 +31,7 @@ before_script:
 
 script:
   - export SQLITE_DSN=sqlite://./test
-  - export PGSQL_DSN=pgsql://127.0.0.1/travis_ci_test
+  # - export PGSQL_DSN=pgsql://127.0.0.1/travis_ci_test
   - sh xp-run xp.unittest.TestRunner src/test/php
   - export MYSQL_DSN=mysql+x://root@127.0.0.1/test
   - sh xp-run xp.unittest.TestRunner rdbms.unittest.integration.MySQLIntegrationTest rdbms.unittest.integration.MySQLDeadlockTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,6 @@ script:
   # - export PGSQL_DSN=pgsql://127.0.0.1/travis_ci_test
   - sh xp-run xp.unittest.TestRunner src/test/php
   - export MYSQL_DSN=mysql+x://root@127.0.0.1/test
-  - sh xp-run xp.unittest.TestRunner rdbms.unittest.integration.MySQLIntegrationTest
+  - sh xp-run xp.unittest.TestRunner rdbms.unittest.integration.MySQLIntegrationTest rdbms.unittest.integration.MySQLDeadlockTest
   - export MYSQL_DSN=mysql+i://root@127.0.0.1/test
-  - sh xp-run xp.unittest.TestRunner rdbms.unittest.integration.MySQLIntegrationTest
+  - sh xp-run xp.unittest.TestRunner rdbms.unittest.integration.MySQLIntegrationTest rdbms.unittest.integration.MySQLDeadlockTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
 
 before_install:
   - mysql -e 'create database IF NOT EXISTS test;' -uroot
-  # - psql -c 'create database travis_ci_test;' -U postgres
+  - psql -c 'create database travis_ci_test;' -U postgres
 
 before_script:
   - curl -sSL https://dl.bintray.com/xp-runners/generic/xp-run-master.sh > xp-run
@@ -32,9 +32,10 @@ before_script:
 
 script:
   - export SQLITE_DSN=sqlite://./test
-  # - export PGSQL_DSN=pgsql://127.0.0.1/travis_ci_test
   - sh xp-run xp.unittest.TestRunner src/test/php
   - export MYSQL_DSN=mysql+x://root@127.0.0.1/test
   - sh xp-run xp.unittest.TestRunner rdbms.unittest.integration.MySQLIntegrationTest rdbms.unittest.integration.MySQLDeadlockTest
   - export MYSQL_DSN=mysql+i://root@127.0.0.1/test
   - sh xp-run xp.unittest.TestRunner rdbms.unittest.integration.MySQLIntegrationTest rdbms.unittest.integration.MySQLDeadlockTest
+  - export PGSQL_DSN=pgsql://127.0.0.1/travis_ci_test
+  - sh xp-run xp.unittest.TestRunner rdbms.unittest.integration.PostgreSQLIntegrationTest rdbms.unittest.integration.PostgreSQLDeadlockTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ before_script:
 
 script:
   - export SQLITE_DSN=sqlite://./test
-  - export __DISABLED_PGSQL_DSN=pgsql://127.0.0.1/travis_ci_test
+  - export PGSQL_DSN=pgsql://127.0.0.1/travis_ci_test
   - sh xp-run xp.unittest.TestRunner src/test/php
-  - export __DISABLED_MYSQL_DSN=mysql+x://root@127.0.0.1/test
+  - export MYSQL_DSN=mysql+x://root@127.0.0.1/test
   - sh xp-run xp.unittest.TestRunner rdbms.unittest.integration.MySQLIntegrationTest rdbms.unittest.integration.MySQLDeadlockTest
-  - export __DISABLED_MYSQL_DSN=mysql+i://root@127.0.0.1/test
+  - export MYSQL_DSN=mysql+i://root@127.0.0.1/test
   - sh xp-run xp.unittest.TestRunner rdbms.unittest.integration.MySQLIntegrationTest rdbms.unittest.integration.MySQLDeadlockTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ php:
 
 matrix:
   allow_failures:
+    - php: hhvm
     - php: nightly
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false
 
 services:
   - mysql
-  # - postgresql
+  - postgresql
 
 php:
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,6 @@ script:
   # - export PGSQL_DSN=pgsql://127.0.0.1/travis_ci_test
   - sh xp-run xp.unittest.TestRunner src/test/php
   - export MYSQL_DSN=mysql+x://root@127.0.0.1/test
-  - sh xp-run xp.unittest.TestRunner rdbms.unittest.integration.MySQLIntegrationTest rdbms.unittest.integration.MySQLDeadlockTest
+  - sh xp-run xp.unittest.TestRunner rdbms.unittest.integration.MySQLIntegrationTest
   - export MYSQL_DSN=mysql+i://root@127.0.0.1/test
-  - sh xp-run xp.unittest.TestRunner rdbms.unittest.integration.MySQLIntegrationTest rdbms.unittest.integration.MySQLDeadlockTest
+  - sh xp-run xp.unittest.TestRunner rdbms.unittest.integration.MySQLIntegrationTest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ init:
 install:
   - if exist .\xp (set CACHED=1) else (mkdir .\xp)
   - if %CACHED%==0 cd .\xp
-  - if %CACHED%==0 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-7.0.9-nts-Win32-VC14-x86.zip -FileName php.zip
+  - if %CACHED%==0 appveyor DownloadFile https://windows.php.net/downloads/releases/archives/php-7.2.5-nts-Win32-VC15-x86.zip -FileName php.zip
   - if %CACHED%==0 appveyor DownloadFile https://getcomposer.org/composer.phar
   - if %CACHED%==0 appveyor DownloadFile https://bintray.com/artifact/download/xp-runners/windows/xp-runners_7.8.2.zip -FileName xp.zip
   - if %CACHED%==0 7z x php.zip -y

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ init:
 install:
   - if exist .\xp (set CACHED=1) else (mkdir .\xp)
   - if %CACHED%==0 cd .\xp
-  - if %CACHED%==0 appveyor DownloadFile https://windows.php.net/downloads/releases/archives/php-7.2.5-nts-Win32-VC15-x86.zip -FileName php.zip
+  - appveyor DownloadFile https://windows.php.net/downloads/releases/archives/php-7.2.5-nts-Win32-VC15-x86.zip -FileName php.zip
   - if %CACHED%==0 appveyor DownloadFile https://getcomposer.org/composer.phar
   - if %CACHED%==0 appveyor DownloadFile https://bintray.com/artifact/download/xp-runners/windows/xp-runners_7.8.2.zip -FileName xp.zip
   - if %CACHED%==0 7z x php.zip -y

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ init:
 install:
   - if exist .\xp (set CACHED=1) else (mkdir .\xp)
   - if %CACHED%==0 cd .\xp
-  - if %CACHED%==0 curl -fsS -o php.zip http://windows.php.net/downloads/releases/archives/php-7.0.9-nts-Win32-VC14-x86.zip
+  - if %CACHED%==0 curl -fsS -o php.zip https://windows.php.net/downloads/releases/archives/php-7.0.9-nts-Win32-VC14-x86.zip
   - if %CACHED%==0 appveyor DownloadFile https://getcomposer.org/composer.phar
   - if %CACHED%==0 appveyor DownloadFile https://bintray.com/artifact/download/xp-runners/windows/xp-runners_7.8.2.zip -FileName xp.zip
   - if %CACHED%==0 7z x php.zip -y

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,9 +9,9 @@ init:
   - set PATH=%PATH%;.\xp
   - set COMPOSER_NO_INTERACTION=1
   - set CACHED=0
-  - cinst -y php
 
 install:
+  - cinst -y php
   - if exist .\xp (set CACHED=1) else (mkdir .\xp)
   - if %CACHED%==0 cd .\xp
   - if %CACHED%==0 appveyor DownloadFile https://getcomposer.org/composer.phar

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,14 +9,13 @@ init:
   - set PATH=%PATH%;.\xp
   - set COMPOSER_NO_INTERACTION=1
   - set CACHED=0
+  - cinst -y php
 
 install:
   - if exist .\xp (set CACHED=1) else (mkdir .\xp)
   - if %CACHED%==0 cd .\xp
-  - appveyor DownloadFile https://windows.php.net/downloads/releases/archives/php-7.2.5-nts-Win32-VC15-x86.zip -FileName php.zip
   - if %CACHED%==0 appveyor DownloadFile https://getcomposer.org/composer.phar
   - if %CACHED%==0 appveyor DownloadFile https://bintray.com/artifact/download/xp-runners/windows/xp-runners_7.8.2.zip -FileName xp.zip
-  - if %CACHED%==0 7z x php.zip -y
   - if %CACHED%==0 7z x xp.zip -y
   - if %CACHED%==0 cd ..
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,11 +11,12 @@ init:
   - set CACHED=0
 
 install:
-  - cinst -y php
   - if exist .\xp (set CACHED=1) else (mkdir .\xp)
   - if %CACHED%==0 cd .\xp
+  - if %CACHED%==0 curl -fsS -o php.zip http://windows.php.net/downloads/releases/archives/php-7.0.9-nts-Win32-VC14-x86.zip
   - if %CACHED%==0 appveyor DownloadFile https://getcomposer.org/composer.phar
   - if %CACHED%==0 appveyor DownloadFile https://bintray.com/artifact/download/xp-runners/windows/xp-runners_7.8.2.zip -FileName xp.zip
+  - if %CACHED%==0 7z x php.zip -y
   - if %CACHED%==0 7z x xp.zip -y
   - if %CACHED%==0 cd ..
   - ps: |

--- a/src/main/php/rdbms/ConnectionManager.class.php
+++ b/src/main/php/rdbms/ConnectionManager.class.php
@@ -1,7 +1,7 @@
 <?php namespace rdbms;
 
-use util\Configurable;
 use rdbms\DSN;
+use util\Configurable;
 
 /**
  * ConnectionManager holds connections to databases
@@ -159,12 +159,10 @@ class ConnectionManager implements Configurable {
    * @return  rdbms.DBConnection
    */
   protected function conn($name, $value) {
-    if ($value instanceof DBConnection) return $value;
-    if (is_string($value)) {
-
-      // Resolve lazy-loading DSNs
-      $this->pool[$name]= DriverManager::getConnection($value);
-      return $this->pool[$name];
+    if ($value instanceof DBConnection) {
+      return $value;
+    } else if (is_string($value)) {         // Resolve lazy-loading DSNs
+      return $this->pool[$name]= DriverManager::getConnection($value, false);
     }
     
     throw new DriverNotSupportedException('Neither a connection string nor a rdbms.DBConnection given.');

--- a/src/main/php/rdbms/DSN.class.php
+++ b/src/main/php/rdbms/DSN.class.php
@@ -1,7 +1,7 @@
 <?php namespace rdbms;
 
-use peer\URL;
 use lang\Value;
+use peer\URL;
 use util\Objects;
 
 define('DB_STORE_RESULT',     0x0001);
@@ -14,12 +14,11 @@ define('DB_NEWLINK',          0x0010);
  * DSN
  *
  * DSN syntax:
- * <pre>
- *   driver://[username[:password]]@host[:port][/database][?flag=value[&flag2=value2]]
- * </pre>
+ * ```
+ * driver://[username[:password]]@host[:port][/database][?flag=value[&flag2=value2]]
+ * ```
  *
- * @test     xp://net.xp_framework.unittest.rdbms.DSNTest
- * @purpose  Unified connect string
+ * @test  xp://net.xp_framework.unittest.rdbms.DSNTest
  */
 class DSN implements Value {
   public 

--- a/src/main/php/rdbms/PersistentConnection.class.php
+++ b/src/main/php/rdbms/PersistentConnection.class.php
@@ -1,5 +1,5 @@
 <?php namespace rdbms;
- 
+
 class PersistentConnection extends DBConnection {
   private $conn;
 
@@ -39,10 +39,10 @@ class PersistentConnection extends DBConnection {
 
   /** @return rdbms.DSN */
   public function getDSN() { return $this->conn->getDSN(); }
-  
+
   /** @return string */
   public function hashCode() { return 'P:'.$this->conn->hashCode(); }
-  
+
   /** @return  string */
   public function toString() { return 'Persisent('.$this->conn->toString().')'; }
 
@@ -51,10 +51,10 @@ class PersistentConnection extends DBConnection {
 
   /** @return int */
   public function getTimeout() { return $this->conn->getTimeout(); }
-  
+
   /** @param int flag */
   public function setFlag($flag) { $this->conn->setFlag($flag); }
-  
+
   /** @return bool */
   public function hasChanged() { return $this->conn->hasChanged(); }
 
@@ -77,7 +77,7 @@ class PersistentConnection extends DBConnection {
 
   /** @return bool success */
   public function close() { return $this->conn->close(); }
-  
+
   /**
    * Select database
    *
@@ -140,7 +140,7 @@ class PersistentConnection extends DBConnection {
       return $this->conn->begin($transaction);
     });
   }
-  
+
   /**
    * Retrieve transaction state
    *
@@ -150,7 +150,7 @@ class PersistentConnection extends DBConnection {
   public function transtate($name) {
     return $this->conn->transtate($name);
   }
-  
+
   /**
    * Rollback a transaction
    *
@@ -160,7 +160,7 @@ class PersistentConnection extends DBConnection {
   public function rollback($name) {
     return $this->conn->rollback($name);
   }
-  
+
   /**
    * Commit a transaction
    *
@@ -169,5 +169,5 @@ class PersistentConnection extends DBConnection {
    */
   public function commit($name) {
     return $this->conn->commit($name);
-  } 
+  }
 }

--- a/src/main/php/rdbms/PersistentConnection.class.php
+++ b/src/main/php/rdbms/PersistentConnection.class.php
@@ -12,13 +12,13 @@ class PersistentConnection extends DBConnection {
   /**
    * Constructor
    *
-   * @param  rdbms.DSN|rdbms.DBConnection $arg
+   * @param  string|rdbms.DSN|rdbms.DBConnection $arg
    */
   public function __construct($arg) {
     if ($arg instanceof DBConnection) {
       $this->conn= $arg;
     } else {
-      $this->conn= DriverManager::getConnection($arg);
+      $this->conn= DriverManager::getConnection($arg, false);
     }
   }
 

--- a/src/main/php/rdbms/PersistentConnection.class.php
+++ b/src/main/php/rdbms/PersistentConnection.class.php
@@ -41,7 +41,7 @@ class PersistentConnection extends DBConnection {
         return $block();
       }
     } catch (SQLConnectException $e) {
-      // $this->conn->close();
+      $this->conn->close();
       throw $e;
     } catch (SQLStateException $e) {
       $this->conn->close();

--- a/src/main/php/rdbms/PersistentConnection.class.php
+++ b/src/main/php/rdbms/PersistentConnection.class.php
@@ -1,0 +1,173 @@
+<?php namespace rdbms;
+ 
+class PersistentConnection extends DBConnection {
+  private $conn;
+
+  /**
+   * Constructor
+   *
+   * @param  rdbms.DSN|rdbms.DBConnection $arg
+   */
+  public function __construct($arg) {
+    if ($arg instanceof DBConnection) {
+      $this->conn= $arg;
+    } else {
+      $this->conn= DriverManager::getConnection($arg);
+    }
+  }
+
+  /**
+   * Executes a block of SQL queries. Handles reconnecting if necessary
+   *
+   * @param  function(): var $block
+   * @return var
+   */
+  private function execute($block) {
+    try {
+      return $block();
+    } catch (SQLConnectionClosedException $e) {
+      $this->conn->connect($reconnect= true);
+      return $block();
+    } catch (SQLConnectException $e) {
+      $this->conn->close();
+      throw $e;
+    } catch (SQLStateException $e) {
+      $this->conn->close();
+      throw $e;
+    }
+  }
+
+  /** @return rdbms.DSN */
+  public function getDSN() { return $this->conn->getDSN(); }
+  
+  /** @return string */
+  public function hashCode() { return 'P:'.$this->conn->hashCode(); }
+  
+  /** @return  string */
+  public function toString() { return 'Persisent('.$this->conn->toString().')'; }
+
+  /** @param int timeout */
+  public function setTimeout($timeout) { $this->conn->setTimeout($timeout); }
+
+  /** @return int */
+  public function getTimeout() { return $this->conn->getTimeout(); }
+  
+  /** @param int flag */
+  public function setFlag($flag) { $this->conn->setFlag($flag); }
+  
+  /** @return bool */
+  public function hasChanged() { return $this->conn->hasChanged(); }
+
+  /** @return rdbms.StatementFormatter */
+  public function getFormatter() { return $this->conn->getFormatter(); }
+
+  /**
+   * Prepare an SQL statement
+   *
+   * @param  string $statement
+   * @param  var... $args
+   * @return string
+   */
+  public function prepare($statement, ... $args) {
+    return $this->conn->prepare($statement, ...$args);
+  }
+
+  /** @return bool success */
+  public function connect() { return $this->conn->connect(); }  
+
+  /** @return bool success */
+  public function close() { return $this->conn->close(); }
+  
+  /**
+   * Select database
+   *
+   * @param   string db name of database to select
+   * @return  bool success
+   */
+  public function selectdb($db) {
+    return $this->execute(function() use($db) {
+      return $this->conn->selectdb($db);
+    });
+  }
+
+  /**
+   * Retrieve identity
+   *
+   * @return  var identity value
+   */
+  public function identity($field= null) {
+    return $this->execute(function() use($field) {
+      return $this->conn->identity($field);
+    });
+  }
+
+  /**
+   * Execute any statement
+   *
+   * @param  string $statement
+   * @param  var... $args
+   * @return rdbms.ResultSet
+   * @throws rdbms.SQLException
+   */
+  public function query($statement, ...$args) {
+    return $this->execute(function() use($statement, $args) {
+      return $this->conn->query($statement, ...$args);
+    });
+  }
+
+  /**
+   * Execute any statement
+   *
+   * @param  string $statement
+   * @param  var... $args
+   * @return rdbms.ResultSet
+   * @throws rdbms.SQLException
+   */
+  public function open($statement, ...$args) {
+    return $this->execute(function() use($statement, $args) {
+      return $this->conn->open($statement, ...$args);
+    });
+  }
+
+  /**
+   * Begin a transaction
+   *
+   * @param   rdbms.Transaction transaction
+   * @return  rdbms.Transaction
+   */
+  public function begin($transaction) {
+    return $this->execute(function() use($transaction) {
+      return $this->conn->begin($transaction);
+    });
+  }
+  
+  /**
+   * Retrieve transaction state
+   *
+   * @param   string name
+   * @return  var state
+   */
+  public function transtate($name) {
+    return $this->conn->transtate($name);
+  }
+  
+  /**
+   * Rollback a transaction
+   *
+   * @param   string name
+   * @return  bool success
+   */
+  public function rollback($name) {
+    return $this->conn->rollback($name);
+  }
+  
+  /**
+   * Commit a transaction
+   *
+   * @param   string name
+   * @return  bool success
+   */
+  public function commit($name) {
+    return $this->conn->commit($name);
+  } 
+}

--- a/src/main/php/rdbms/PersistentConnection.class.php
+++ b/src/main/php/rdbms/PersistentConnection.class.php
@@ -37,7 +37,8 @@ class PersistentConnection extends DBConnection {
         $this->conn->close();
         throw $e;
       } else {
-        $this->conn->connect($reconnect= true);
+        $this->conn->close();
+        $this->conn->connect();
         return $block();
       }
     } catch (SQLConnectException $e) {

--- a/src/main/php/rdbms/PersistentConnection.class.php
+++ b/src/main/php/rdbms/PersistentConnection.class.php
@@ -41,7 +41,7 @@ class PersistentConnection extends DBConnection {
         return $block();
       }
     } catch (SQLConnectException $e) {
-      $this->conn->close();
+      // $this->conn->close();
       throw $e;
     } catch (SQLStateException $e) {
       $this->conn->close();

--- a/src/main/php/rdbms/mysqli/MySQLiConnection.class.php
+++ b/src/main/php/rdbms/mysqli/MySQLiConnection.class.php
@@ -1,9 +1,9 @@
 <?php namespace rdbms\mysqli;
 
 use rdbms\DBConnection;
-use rdbms\Transaction;
-use rdbms\StatementFormatter;
 use rdbms\QuerySucceeded;
+use rdbms\StatementFormatter;
+use rdbms\Transaction;
 
 /**
  * Connection to MySQL Databases
@@ -196,14 +196,19 @@ class MySQLiConnection extends DBConnection {
       switch ($code) {
         case 2006: // MySQL server has gone away
         case 2013: // Lost connection to MySQL server during query
-          throw new \rdbms\SQLConnectionClosedException('Statement failed: '.$message, $sql, $code);
+          $e= new \rdbms\SQLConnectionClosedException($message, $sql, $code);
+          break;
 
         case 1213: // Deadlock
-          throw new \rdbms\SQLDeadlockException($message, $sql, $code);
-        
+          $e= new \rdbms\SQLDeadlockException($message, $sql, $code);
+          break;
+
         default:   // Other error
-          throw new \rdbms\SQLStatementFailedException($message, $sql, $code);
+          $e= new \rdbms\SQLStatementFailedException($message, $sql, $code);
+          break;
       }
+      \xp::gc(__FILE__);
+      throw $e;
     } else if (true === $r) {
       return new QuerySucceeded(mysqli_affected_rows($this->handle));
     } else if ($buffered) {

--- a/src/test/php/rdbms/unittest/DBTest.class.php
+++ b/src/test/php/rdbms/unittest/DBTest.class.php
@@ -1,13 +1,13 @@
 <?php namespace rdbms\unittest;
  
+use rdbms\DriverManager;
 use rdbms\ResultSet;
 use rdbms\SQLConnectException;
-use rdbms\SQLStateException;
 use rdbms\SQLConnectionClosedException;
+use rdbms\SQLStateException;
 use rdbms\SQLStatementFailedException;
-use rdbms\DriverManager;
-use unittest\TestCase;
 use rdbms\unittest\mock\MockResultSet;
+use unittest\TestCase;
 
 /**
  * Test rdbms API
@@ -20,7 +20,7 @@ class DBTest extends TestCase {
    * Setup function
    */
   public function setUp() {
-    $this->conn= DriverManager::getConnection('mock://mock/MOCKDB?autoconnect=0');
+    $this->conn= DriverManager::getConnection('mock://mock/MOCKDB?autoconnect=0', false);
     $this->assertEquals(0, $this->conn->flags & DB_AUTOCONNECT);
   }
   

--- a/src/test/php/rdbms/unittest/DataSetTest.class.php
+++ b/src/test/php/rdbms/unittest/DataSetTest.class.php
@@ -1,19 +1,19 @@
 <?php namespace rdbms\unittest;
 
+use lang\IllegalArgumentException;
+use rdbms\Column;
+use rdbms\DBObserver;
+use rdbms\DriverManager;
 use rdbms\Peer;
 use rdbms\ResultIterator;
-use rdbms\Column;
 use rdbms\SQLException;
-use util\NoSuchElementException;
-use lang\IllegalArgumentException;
-use unittest\TestCase;
-use rdbms\DriverManager;
-use rdbms\DBObserver;
-use util\Date;
-use util\DateUtil;
 use rdbms\Statement;
 use rdbms\unittest\dataset\Job;
 use rdbms\unittest\mock\MockResultSet;
+use unittest\TestCase;
+use util\Date;
+use util\DateUtil;
+use util\NoSuchElementException;
 
 /**
  * O/R-mapping API unit test
@@ -28,7 +28,7 @@ class DataSetTest extends TestCase {
    * Setup method
    */
   public function setUp() {
-    Job::getPeer()->setConnection(DriverManager::getConnection('mock://mock/JOBS?autoconnect=1'));
+    Job::getPeer()->setConnection(DriverManager::getConnection('mock://mock/JOBS', false));
   }
   
   /**

--- a/src/test/php/rdbms/unittest/DriverManagerTest.class.php
+++ b/src/test/php/rdbms/unittest/DriverManagerTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace rdbms\unittest;
 
-use rdbms\DriverNotSupportedException;
 use lang\FormatException;
 use lang\IllegalArgumentException;
 use rdbms\DriverManager;
+use rdbms\DriverNotSupportedException;
 
 /**
  * TestCase
@@ -57,7 +57,7 @@ class DriverManagerTest extends \unittest\TestCase {
   public function mysqlxProvidedByDefaultDrivers() {
     $this->assertInstanceOf(
       'rdbms.mysqlx.MySqlxConnection', 
-      DriverManager::getConnection('mysql+x://localhost')
+      DriverManager::getConnection('mysql+x://localhost', false)
     );
   }
 
@@ -79,7 +79,7 @@ class DriverManagerTest extends \unittest\TestCase {
     $this->register('mock', \lang\XPClass::forName('rdbms.unittest.mock.MockConnection'));
     $this->assertInstanceOf(
       'rdbms.unittest.mock.MockConnection',
-      DriverManager::getConnection('mock://localhost')
+      DriverManager::getConnection('mock://localhost', false)
     );
   }
 
@@ -110,7 +110,7 @@ class DriverManagerTest extends \unittest\TestCase {
 
     $this->assertInstanceOf(
       'rdbms.unittest.mock.AMockConnection', 
-      DriverManager::getConnection('test://localhost')
+      DriverManager::getConnection('test://localhost', false)
     );
   }
 }

--- a/src/test/php/rdbms/unittest/FinderTest.class.php
+++ b/src/test/php/rdbms/unittest/FinderTest.class.php
@@ -1,18 +1,18 @@
 <?php namespace rdbms\unittest;
 
-use rdbms\Peer;
-use rdbms\finder\FinderMethod;
-use rdbms\SQLExpression;
-use lang\MethodNotImplementedException;
 use lang\IllegalArgumentException;
-use rdbms\finder\FinderException;
-use rdbms\finder\NoSuchEntityException;
-use unittest\TestCase;
+use lang\MethodNotImplementedException;
 use rdbms\DriverManager;
+use rdbms\Peer;
+use rdbms\SQLExpression;
+use rdbms\finder\FinderException;
+use rdbms\finder\FinderMethod;
 use rdbms\finder\GenericFinder;
+use rdbms\finder\NoSuchEntityException;
 use rdbms\unittest\dataset\Job;
 use rdbms\unittest\dataset\JobFinder;
 use rdbms\unittest\mock\MockResultSet;
+use unittest\TestCase;
 
 /**
  * TestCase
@@ -28,7 +28,7 @@ class FinderTest extends TestCase {
    */
   public function setUp() {
     $this->fixture= new JobFinder();
-    $this->fixture->getPeer()->setConnection(DriverManager::getConnection('mock://mock/JOBS?autoconnect=1'));
+    $this->fixture->getPeer()->setConnection(DriverManager::getConnection('mock://mock/JOBS', false));
   }
 
   /**

--- a/src/test/php/rdbms/unittest/PersistentConnectionTest.class.php
+++ b/src/test/php/rdbms/unittest/PersistentConnectionTest.class.php
@@ -21,12 +21,12 @@ class PersistentConnectionTest extends TestCase {
 
   #[@test]
   public function can_create_with_connection() {
-    new PersistentConnection(DriverManager::getConnection('mock://test'));
+    new PersistentConnection(DriverManager::getConnection('mock://test', false));
   }
 
   #[@test]
   public function connect() {
-    $conn= DriverManager::getConnection('mock://test');
+    $conn= DriverManager::getConnection('mock://test', false);
     $fixture= new PersistentConnection($conn);
     $fixture->connect();
     $this->assertTrue($conn->isConnected());
@@ -34,7 +34,7 @@ class PersistentConnectionTest extends TestCase {
 
   #[@test]
   public function close() {
-    $conn= DriverManager::getConnection('mock://test');
+    $conn= DriverManager::getConnection('mock://test', false);
     $fixture= new PersistentConnection($conn);
     $fixture->connect();
     $fixture->close();
@@ -43,35 +43,35 @@ class PersistentConnectionTest extends TestCase {
 
   #[@test]
   public function identity() {
-    $conn= DriverManager::getConnection('mock://test');
+    $conn= DriverManager::getConnection('mock://test', false);
     $conn->setIdentityValue(6100);
     $this->assertEquals(6100, (new PersistentConnection($conn))->identity());
   }
 
   #[@test]
   public function query_with_params() {
-    $conn= DriverManager::getConnection('mock://test');
+    $conn= DriverManager::getConnection('mock://test', false);
     (new PersistentConnection($conn))->query('select * from test where id = %d', 6100);
     $this->assertEquals('select * from test where id = 6100', $conn->getStatement());
   }
 
   #[@test]
   public function open_with_params() {
-    $conn= DriverManager::getConnection('mock://test');
+    $conn= DriverManager::getConnection('mock://test', false);
     (new PersistentConnection($conn))->open('select * from test where id = %d', 6100);
     $this->assertEquals('select * from test where id = 6100', $conn->getStatement());
   }
 
   #[@test, @expect(class= SQLStatementFailedException::class, withMessage= 'Syntax error')]
   public function query_failures_thrown() {
-    $conn= DriverManager::getConnection('mock://test');
+    $conn= DriverManager::getConnection('mock://test', false);
     $conn->makeQueryFail(1000, 'Syntax error');
     (new PersistentConnection($conn))->query('select');
   }
 
   #[@test]
   public function reconnects_and_reruns_query_when_server_disconnects() {
-    $conn= DriverManager::getConnection('mock://test');
+    $conn= DriverManager::getConnection('mock://test', false);
     $conn->connect();
     $conn->addResultSet(new MockResultSet([['id' => 'Test']]));
     $conn->letServerDisconnect();
@@ -82,7 +82,7 @@ class PersistentConnectionTest extends TestCase {
 
   #[@test, @expect(SQLConnectionClosedException::class)]
   public function does_not_rerun_query_inside_transaction() {
-    $conn= DriverManager::getConnection('mock://test');
+    $conn= DriverManager::getConnection('mock://test', false);
     $conn->connect();
 
     $fixture= new PersistentConnection($conn);
@@ -94,7 +94,7 @@ class PersistentConnectionTest extends TestCase {
 
   #[@test, @expect(SQLStatementFailedException::class)]
   public function rolling_back_transaction() {
-    $conn= DriverManager::getConnection('mock://test');
+    $conn= DriverManager::getConnection('mock://test', false);
     $conn->connect();
 
     $fixture= new PersistentConnection($conn);
@@ -112,7 +112,7 @@ class PersistentConnectionTest extends TestCase {
 
   #[@test]
   public function connection_is_closed_after_connect_errors() {
-    $conn= DriverManager::getConnection('mock://test');
+    $conn= DriverManager::getConnection('mock://test', false);
     $conn->makeConnectFail(401);
 
     $fixture= new PersistentConnection($conn);

--- a/src/test/php/rdbms/unittest/PersistentConnectionTest.class.php
+++ b/src/test/php/rdbms/unittest/PersistentConnectionTest.class.php
@@ -1,0 +1,46 @@
+<?php namespace rdbms\unittest;
+
+use unittest\TestCase;
+use rdbms\PersistentConnection;
+use rdbms\DriverManager;
+use rdbms\Transaction;
+use rdbms\SQLConnectionClosedException;
+use rdbms\unittest\mock\RegisterMockConnection;
+use rdbms\unittest\mock\MockResultSet;
+
+#[@action(new RegisterMockConnection())]
+class PersistentConnectionTest extends TestCase {
+
+  #[@test]
+  public function can_create_with_dsn() {
+    new PersistentConnection('mock://test');
+  }
+
+  #[@test]
+  public function can_create_with_connection() {
+    new PersistentConnection(DriverManager::getConnection('mock://test'));
+  }
+
+  #[@test]
+  public function reconnects_and_reruns_query_when_server_disconnects() {
+    $conn= DriverManager::getConnection('mock://test');
+    $conn->connect();
+    $conn->addResultSet(new MockResultSet([['id' => 'Test']]));
+    $conn->letServerDisconnect();
+
+    $fixture= new PersistentConnection($conn);
+    $this->assertEquals('Test', $fixture->query('select id from test')->next('id'));
+  }
+
+  #[@test, @expect(SQLConnectionClosedException::class)]
+  public function does_not_rerun_query_inside_transaction() {
+    $conn= DriverManager::getConnection('mock://test');
+    $conn->connect();
+
+    $fixture= new PersistentConnection($conn);
+    $tran= $fixture->begin(new Transaction('test'));
+
+    $conn->letServerDisconnect();
+    $fixture->query('select id from test');
+  }
+}

--- a/src/test/php/rdbms/unittest/PersistentConnectionTest.class.php
+++ b/src/test/php/rdbms/unittest/PersistentConnectionTest.class.php
@@ -4,6 +4,7 @@ use unittest\TestCase;
 use rdbms\PersistentConnection;
 use rdbms\DriverManager;
 use rdbms\Transaction;
+use rdbms\SQLStatementFailedException;
 use rdbms\SQLConnectionClosedException;
 use rdbms\unittest\mock\RegisterMockConnection;
 use rdbms\unittest\mock\MockResultSet;
@@ -19,6 +20,51 @@ class PersistentConnectionTest extends TestCase {
   #[@test]
   public function can_create_with_connection() {
     new PersistentConnection(DriverManager::getConnection('mock://test'));
+  }
+
+  #[@test]
+  public function connect() {
+    $conn= DriverManager::getConnection('mock://test');
+    $fixture= new PersistentConnection($conn);
+    $fixture->connect();
+    $this->assertTrue($conn->isConnected());
+  }
+
+  #[@test]
+  public function close() {
+    $conn= DriverManager::getConnection('mock://test');
+    $fixture= new PersistentConnection($conn);
+    $fixture->connect();
+    $fixture->close();
+    $this->assertFalse($conn->isConnected());
+  }
+
+  #[@test]
+  public function identity() {
+    $conn= DriverManager::getConnection('mock://test');
+    $conn->setIdentityValue(6100);
+    $this->assertEquals(6100, (new PersistentConnection($conn))->identity());
+  }
+
+  #[@test]
+  public function query_with_params() {
+    $conn= DriverManager::getConnection('mock://test');
+    (new PersistentConnection($conn))->query('select * from test where id = %d', 6100);
+    $this->assertEquals('select * from test where id = 6100', $conn->getStatement());
+  }
+
+  #[@test]
+  public function open_with_params() {
+    $conn= DriverManager::getConnection('mock://test');
+    (new PersistentConnection($conn))->open('select * from test where id = %d', 6100);
+    $this->assertEquals('select * from test where id = 6100', $conn->getStatement());
+  }
+
+  #[@test, @expect(class= SQLStatementFailedException::class, withMessage= 'Syntax error')]
+  public function query_failures_thrown() {
+    $conn= DriverManager::getConnection('mock://test');
+    $conn->makeQueryFail(1000, 'Syntax error');
+    (new PersistentConnection($conn))->query('select');
   }
 
   #[@test]

--- a/src/test/php/rdbms/unittest/ProjectionTest.class.php
+++ b/src/test/php/rdbms/unittest/ProjectionTest.class.php
@@ -1,18 +1,18 @@
 <?php namespace rdbms\unittest;
 
+use rdbms\Criteria;
 use rdbms\DriverManager;
 use rdbms\Record;
-use util\Date;
-use rdbms\sybase\SybaseConnection;
+use rdbms\criterion\Projections;
+use rdbms\criterion\Restrictions;
 use rdbms\mysql\MySQLConnection;
 use rdbms\pgsql\PostgreSQLConnection;
 use rdbms\sqlite3\SQLite3Connection;
-use rdbms\criterion\Restrictions;
-use rdbms\criterion\Projections;
-use rdbms\Criteria;
+use rdbms\sybase\SybaseConnection;
 use rdbms\unittest\dataset\Job;
 use rdbms\unittest\mock\MockResultSet;
 use rdbms\unittest\mock\RegisterMockConnection;
+use util\Date;
 
 /**
  * TestCase
@@ -232,7 +232,7 @@ class ProjectionTest extends \unittest\TestCase {
 
   #[@test]
   function regressionIteratorDatasetType() {
-    $conn= DriverManager::getConnection('mock://mock/JOBS?autoconnect=1');
+    $conn= DriverManager::getConnection('mock://mock/JOBS', false);
     $conn->setResultSet(new MockResultSet([['count' => 5]]));
     $crit= (new Criteria())->withProjection(Projections::count('*'));
     $this->peer->setConnection($conn);

--- a/src/test/php/rdbms/unittest/QueryTest.class.php
+++ b/src/test/php/rdbms/unittest/QueryTest.class.php
@@ -1,14 +1,14 @@
 <?php namespace rdbms\unittest;
  
-use rdbms\unittest\mock\MockConnection;
-use unittest\TestCase;
-use rdbms\query\SelectQuery;
-use rdbms\query\UpdateQuery;
-use rdbms\query\DeleteQuery;
-use rdbms\query\SetOperation;
 use rdbms\Criteria;
+use rdbms\query\DeleteQuery;
+use rdbms\query\SelectQuery;
+use rdbms\query\SetOperation;
+use rdbms\query\UpdateQuery;
 use rdbms\unittest\dataset\Job;
 use rdbms\unittest\dataset\Person;
+use rdbms\unittest\mock\MockConnection;
+use unittest\TestCase;
 
 /**
  * Test query class
@@ -28,7 +28,7 @@ class QueryTest extends TestCase {
    * Setup method
    */
   public function setUp() {
-    with ($conn= \rdbms\DriverManager::getConnection('mock://mock/JOBS?autoconnect=1')); {
+    with ($conn= \rdbms\DriverManager::getConnection('mock://mock/JOBS', false)); {
       Job::getPeer()->setConnection($conn);
       Person::getPeer()->setConnection($conn);
     }

--- a/src/test/php/rdbms/unittest/RegisteredConnectionManagerTest.class.php
+++ b/src/test/php/rdbms/unittest/RegisteredConnectionManagerTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace rdbms\unittest;
 
-use rdbms\DriverManager;
 use rdbms\ConnectionManager;
+use rdbms\DriverManager;
 
 /**
  * Tests for connection managers with connections programmatically
@@ -22,7 +22,7 @@ class RegisteredConnectionManagerTest extends ConnectionManagerTest {
   protected function instanceWith($dsns) {
     $cm= ConnectionManager::getInstance();
     foreach ($dsns as $name => $dsn) {
-      $conn= DriverManager::getConnection($dsn);
+      $conn= DriverManager::getConnection($dsn, false);
       if (false !== ($p= strpos($name, '.'))) {
         $cm->register($conn, substr($name, 0, $p), substr($name, $p+ 1));
       } else {
@@ -39,7 +39,7 @@ class RegisteredConnectionManagerTest extends ConnectionManagerTest {
 
   #[@test]
   public function registerReturnsConnection() {
-    $conn= DriverManager::getConnection('mock://user:pass@host/db');
+    $conn= DriverManager::getConnection('mock://user:pass@host/db', false);
     $cm= $this->instanceWith([]);
     
     $this->assertEquals($conn, $cm->register($conn));
@@ -47,7 +47,7 @@ class RegisteredConnectionManagerTest extends ConnectionManagerTest {
  
   #[@test]
   public function registerReturnsConnectionWhenPreviouslyRegistered() {
-    $conn= DriverManager::getConnection('mock://user:pass@host/db');
+    $conn= DriverManager::getConnection('mock://user:pass@host/db', false);
     $cm= $this->instanceWith([]);
     $cm->register($conn);
 
@@ -56,8 +56,8 @@ class RegisteredConnectionManagerTest extends ConnectionManagerTest {
 
   #[@test]
   public function registerOverwritesPreviouslyRegistered() {
-    $conn1= DriverManager::getConnection('mock://user:pass@host/db1');
-    $conn2= DriverManager::getConnection('mock://user:pass@host/db2');
+    $conn1= DriverManager::getConnection('mock://user:pass@host/db1', false);
+    $conn2= DriverManager::getConnection('mock://user:pass@host/db2', false);
     $cm= $this->instanceWith([]);
 
     $this->assertEquals($conn1, $cm->register($conn1));

--- a/src/test/php/rdbms/unittest/StatementTest.class.php
+++ b/src/test/php/rdbms/unittest/StatementTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace rdbms\unittest;
  
-use unittest\TestCase;
-use rdbms\Statement;
 use rdbms\DriverManager;
+use rdbms\Statement;
 use rdbms\unittest\dataset\Job;
+use unittest\TestCase;
 
 /**
  * Test Statement class
@@ -19,9 +19,9 @@ class StatementTest extends TestCase {
    * Setup method
    */
   public function setUp() {
-    $this->conn= DriverManager::getConnection('mock://mock/JOBS?autoconnect=1');
+    $this->conn= DriverManager::getConnection('mock://mock/JOBS', false);
     $this->peer= Job::getPeer();
-    $this->peer->setConnection(DriverManager::getConnection('mock://mock/JOBS?autoconnect=1'));
+    $this->peer->setConnection($this->conn);
   }
   
   /**

--- a/src/test/php/rdbms/unittest/integration/MySQLIntegrationTest.class.php
+++ b/src/test/php/rdbms/unittest/integration/MySQLIntegrationTest.class.php
@@ -1,5 +1,8 @@
 <?php namespace rdbms\unittest\integration;
 
+use rdbms\PersistentConnection;
+use rdbms\SQLStatementFailedException;
+
 /**
  * MySQL integration test
  *
@@ -241,5 +244,20 @@ class MySQLIntegrationTest extends RdbmsIntegrationTest {
     // produces a warning.
     $this->assertEquals('💩', $this->db()->query("select '💩' as poop")->next('poop'));
     $this->assertNull($this->db()->query('show warnings')->next());
+  }
+
+  #[@test]
+  public function reconnects_when_server_disconnects() {
+    $conn= new PersistentConnection($this->db());
+    $before= $conn->query('select connection_id() as id')->next('id');
+
+    try {
+      $conn->query('kill %d', $before);
+    } catch (SQLException $expected) {
+      // errorcode 1927: Connection was killed (sqlstate 70100)
+    }
+
+    $after= $conn->query('select connection_id() as id')->next('id');
+    $this->assertNotEquals($before, $after, 'Connection IDs must be different');
   }
 }

--- a/src/test/php/rdbms/unittest/integration/MySQLIntegrationTest.class.php
+++ b/src/test/php/rdbms/unittest/integration/MySQLIntegrationTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace rdbms\unittest\integration;
 
 use rdbms\PersistentConnection;
-use rdbms\SQLStatementFailedException;
+use rdbms\SQLException;
 
 /**
  * MySQL integration test

--- a/src/test/php/rdbms/unittest/integration/PostgreSQLIntegrationTest.class.php
+++ b/src/test/php/rdbms/unittest/integration/PostgreSQLIntegrationTest.class.php
@@ -1,5 +1,8 @@
 <?php namespace rdbms\unittest\integration;
 
+use rdbms\PersistentConnection;
+use rdbms\SQLException;
+
 /**
  * PostgreSQL integration test
  *
@@ -209,4 +212,19 @@ class PostgreSQLIntegrationTest extends RdbmsIntegrationTest {
 
   #[@test, @ignore('Cast to smallint not supported by PostgreSQL')]
   public function selectSmallintZero() { }
+
+  #[@test]
+  public function reconnects_when_server_disconnects() {
+    $conn= new PersistentConnection($this->db());
+    $before= $conn->query('select pg_backend_pid() as id')->next('id');
+
+    try {
+      $conn->query('select pg_terminate_backend(%d)', $before);
+    } catch (SQLException $expected) {
+      // errorcode 1927: Connection was killed (sqlstate 70100)
+    }
+
+    $after= $conn->query('select pg_backend_pid() as id')->next('id');
+    $this->assertNotEquals($before, $after, 'Connection IDs must be different');
+  }
 }

--- a/src/test/php/rdbms/unittest/integration/RdbmsIntegrationTest.class.php
+++ b/src/test/php/rdbms/unittest/integration/RdbmsIntegrationTest.class.php
@@ -1,20 +1,20 @@
 <?php namespace rdbms\unittest\integration;
 
-use util\Date;
-use rdbms\ResultSet;
-use rdbms\DSN;
-use rdbms\DBEvent;
-use rdbms\SQLStateException;
-use rdbms\SQLConnectException;
-use rdbms\SQLStatementFailedException;
-use rdbms\SQLException;
-use util\Observer;
-use unittest\TestCase;
-use unittest\PrerequisitesNotMetError;
-use rdbms\DriverManager;
-use util\Bytes;
-use lang\Throwable;
 use lang\MethodNotImplementedException;
+use lang\Throwable;
+use rdbms\DBEvent;
+use rdbms\DSN;
+use rdbms\DriverManager;
+use rdbms\ResultSet;
+use rdbms\SQLConnectException;
+use rdbms\SQLException;
+use rdbms\SQLStateException;
+use rdbms\SQLStatementFailedException;
+use unittest\PrerequisitesNotMetError;
+use unittest\TestCase;
+use util\Bytes;
+use util\Date;
+use util\Observer;
 
 /**
  * Base class for all RDBMS integration tests

--- a/src/test/php/rdbms/unittest/mock/MockConnection.class.php
+++ b/src/test/php/rdbms/unittest/mock/MockConnection.class.php
@@ -155,6 +155,15 @@ class MockConnection extends \rdbms\DBConnection {
    }
 
   /**
+   * Mock: Get whether connection has been established
+   *
+   * @return  bool
+   */
+  public function isConnected() {
+    return $this->_connected;
+  }
+
+  /**
    * Connect
    *
    * @param   bool reconnect default FALSE

--- a/src/test/php/rdbms/unittest/mock/MockConnection.class.php
+++ b/src/test/php/rdbms/unittest/mock/MockConnection.class.php
@@ -1,7 +1,7 @@
 <?php namespace rdbms\unittest\mock;
 
-use rdbms\Transaction;
 use rdbms\StatementFormatter;
+use rdbms\Transaction;
 
 /**
  * Mock database connection.
@@ -292,7 +292,9 @@ class MockConnection extends \rdbms\DBConnection {
    * @param   string name
    * @return  mixed state
    */
-  public function transtate($name) { }
+  public function transtate($name) {
+    return $this->query('select @@transtate as state')->next('state');
+  }
   
   /**
    * Rollback a transaction
@@ -300,7 +302,9 @@ class MockConnection extends \rdbms\DBConnection {
    * @param   string name
    * @return  bool success
    */
-  public function rollback($name) { }
+  public function rollback($name) {
+    $this->query('rollback %s', $name);
+  }
   
   /**
    * Commit a transaction
@@ -308,5 +312,7 @@ class MockConnection extends \rdbms\DBConnection {
    * @param   string name
    * @return  bool success
    */
-  public function commit($name) { }
+  public function commit($name) {
+    $this->query('commit %s', $name);
+  }
 }


### PR DESCRIPTION
This pull request adds a `rdbms.PersistentConnection` class which wraps around other connections, reconnecting when a disconnect has been received from the server.

```php
$conn= DriverManager::getConnection('mysql://user:pass@example.com');
$conn= new PersistentConnection($conn);

// ...or, shorter:
$conn= new PersistentConnection('mysql://user:pass@example.com');
```
