### PR TITLE
Connection handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ php:
 
 matrix:
   allow_failures:
+    - php: hhvm
     - php: nightly
 
 before_install:
@@ -31,9 +32,10 @@ before_script:
 
 script:
   - export SQLITE_DSN=sqlite://./test
-  - export __DISABLED_PGSQL_DSN=pgsql://127.0.0.1/travis_ci_test
   - sh xp-run xp.unittest.TestRunner src/test/php
-  - export __DISABLED_MYSQL_DSN=mysql+x://root@127.0.0.1/test
+  - export MYSQL_DSN=mysql+x://root@127.0.0.1/test
   - sh xp-run xp.unittest.TestRunner rdbms.unittest.integration.MySQLIntegrationTest rdbms.unittest.integration.MySQLDeadlockTest
-  - export __DISABLED_MYSQL_DSN=mysql+i://root@127.0.0.1/test
+  - export MYSQL_DSN=mysql+i://root@127.0.0.1/test
   - sh xp-run xp.unittest.TestRunner rdbms.unittest.integration.MySQLIntegrationTest rdbms.unittest.integration.MySQLDeadlockTest
+  - export PGSQL_DSN=pgsql://127.0.0.1/travis_ci_test
+  - sh xp-run xp.unittest.TestRunner rdbms.unittest.integration.PostgreSQLIntegrationTest rdbms.unittest.integration.PostgreSQLDeadlockTest

--- a/src/main/php/rdbms/Connections.class.php
+++ b/src/main/php/rdbms/Connections.class.php
@@ -1,0 +1,69 @@
+<?php namespace rdbms;
+
+class Connections {
+  private $automatic, $attempts;
+
+  /**
+   * Creates a new instance
+   *
+   * @param  bool $automatic Autoconnect semantics, defaults to TRUE
+   * @param  int $attempts Reconnect attempts when disconnected, defaults to 1
+   */
+  public function __construct($automatic= true, $attempts= 1) {
+    $this->automatic= $automatic;
+    $this->attempts= $attempts;
+  }
+
+  /**
+   * Set whether to use autoconnect semantics
+   *
+   * @param  bool $automatic
+   * @return self
+   */
+  public function automatic($automatic) {
+    $this->automatic= $automatic;
+    return $this;
+  }
+
+  /**
+   * Set how often to try reconnecting after server disconnected
+   *
+   * @param  int $attempts
+   * @return self
+   */
+  public function reconnect($attempts) {
+    $this->attempts= $attempts;
+    return $this;
+  }
+
+  /**
+   * Establish connection if necessary
+   *
+   * @param  rdbms.DBConnection $conn
+   * @return void
+   */
+  public function establish($conn) {
+    if ($this->automatic) {
+      if (false === $conn->connect()) {
+        throw new SQLStateException('Previously failed to connect.');
+      }
+    } else {
+      throw new SQLStateException('Not connected');
+    }
+  }
+  
+  /**
+   * Handle situation when server disconnected
+   *
+   * @param  rdbms.DBConnection $conn
+   * @param  int $tries
+   * @return bool Whether to retry
+   */
+  public function retry($conn, $tries) {
+    if ($tries > $this->attempts) return false;
+
+    $conn->close();
+    $conn->connect();
+    return true;
+  }
+}

--- a/src/main/php/rdbms/Connections.class.php
+++ b/src/main/php/rdbms/Connections.class.php
@@ -44,7 +44,7 @@ class Connections {
    */
   public function establish($conn) {
     if ($this->automatic) {
-      if (false === $conn->connect()) {
+      if (false === $conn->connect($reconnect= $this->attempts > 0)) {
         throw new SQLStateException('Previously failed to connect.');
       }
     } else {

--- a/src/main/php/rdbms/DBConnection.class.php
+++ b/src/main/php/rdbms/DBConnection.class.php
@@ -1,9 +1,9 @@
 <?php namespace rdbms;
  
-use util\log\Logger;
+use lang\XPClass;
 use util\Observable;
 use util\TimeZone;
-use lang\XPClass;
+use util\log\Logger;
 
 /**
  * Provide an interface from which all other database connection
@@ -11,14 +11,16 @@ use lang\XPClass;
  */
 abstract class DBConnection extends Observable {
   public 
-    $handle  = null,
-    $dsn     = null,
-    $tz      = null,
-    $timeout = 0,
-    $flags   = 0;
+    $handle      = null,
+    $dsn         = null,
+    $tz          = null,
+    $timeout     = 0,
+    $flags       = 0,
+    $connections = null;
   
   protected
-    $formatter= null;
+    $formatter   = null,
+    $transaction = 0;
 
   /**
    * Constructor
@@ -56,6 +58,11 @@ abstract class DBConnection extends Observable {
     if ($tz= $dsn->getProperty('timezone', false)) {
       $this->tz= new TimeZone($tz);
     }
+
+    $this->connections= new Connections(
+      $this->flags & DB_AUTOCONNECT,
+      $this->dsn->getProperty('reconnect', 1)
+    );
   }
 
   /**

--- a/src/main/php/rdbms/DSN.class.php
+++ b/src/main/php/rdbms/DSN.class.php
@@ -1,7 +1,7 @@
 <?php namespace rdbms;
 
-use peer\URL;
 use lang\Value;
+use peer\URL;
 use util\Objects;
 
 define('DB_STORE_RESULT',     0x0001);
@@ -14,12 +14,11 @@ define('DB_NEWLINK',          0x0010);
  * DSN
  *
  * DSN syntax:
- * <pre>
- *   driver://[username[:password]]@host[:port][/database][?flag=value[&flag2=value2]]
- * </pre>
+ * ```
+ * driver://[username[:password]]@host[:port][/database][?flag=value[&flag2=value2]]
+ * ```
  *
- * @test     xp://net.xp_framework.unittest.rdbms.DSNTest
- * @purpose  Unified connect string
+ * @test  xp://net.xp_framework.unittest.rdbms.DSNTest
  */
 class DSN implements Value {
   public 

--- a/src/main/php/rdbms/SQLConnectionClosedException.class.php
+++ b/src/main/php/rdbms/SQLConnectionClosedException.class.php
@@ -1,13 +1,24 @@
 <?php namespace rdbms;
 
-
-
 /**
  * Indicates the connection was lost during an SQL query
  *
- * @see      rfc://0058
- * @purpose  Exception
+ * @see   rfc://0058
  */
 class SQLConnectionClosedException extends SQLStatementFailedException {
 
+  /**
+   * Constructor
+   *
+   * @param   string $message
+   * @param   int $tries
+   * @param   string $sql default NULL the SQL query string sent
+   * @param   int $errorcode default -1
+   */
+  public function __construct($message, $tries, $sql= null, $errorcode= -1) {
+    if ($tries > 1) {
+      $message.= ', retried '.($tries - 1).' times';
+    }
+    parent::__construct($message, $sql, $errorcode);
+  }
 }

--- a/src/main/php/rdbms/ibase/InterBaseConnection.class.php
+++ b/src/main/php/rdbms/ibase/InterBaseConnection.class.php
@@ -184,8 +184,9 @@ class InterBaseConnection extends DBConnection {
    * @return  bool success
    */
   public function rollback($name) {
+    $this->query('rollback transaction xp_%c', $name);
     $this->transaction--;
-    return $this->query('rollback transaction xp_%c', $name);
+    return true;
   }
   
   /**
@@ -195,7 +196,8 @@ class InterBaseConnection extends DBConnection {
    * @return  bool success
    */
   public function commit($name) {
+    $this->query('commit transaction xp_%c', $name);
     $this->transaction--;
-    return $this->query('commit transaction xp_%c', $name);
+    return true;
   }
 }

--- a/src/main/php/rdbms/ibase/InterBaseConnection.class.php
+++ b/src/main/php/rdbms/ibase/InterBaseConnection.class.php
@@ -1,9 +1,9 @@
 <?php namespace rdbms\ibase;
 
 use rdbms\DBConnection;
-use rdbms\Transaction;
-use rdbms\StatementFormatter;
 use rdbms\QuerySucceeded;
+use rdbms\StatementFormatter;
+use rdbms\Transaction;
 
 /**
  * Connection to InterBase/FireBird databases using client libraries
@@ -124,21 +124,22 @@ class InterBaseConnection extends DBConnection {
    * @throws  rdbms.SQLException
    */
   protected function query0($sql, $buffered= true) {
-    if (!is_resource($this->handle)) {
-      if (!($this->flags & DB_AUTOCONNECT)) throw new \rdbms\SQLStateException('Not connected');
-      $c= $this->connect();
-      
-      // Check for subsequent connection errors
-      if (false === $c) throw new \rdbms\SQLStateException('Previously failed to connect');
-    }
-    
-    $result= ibase_query($sql, $this->handle);
+    is_resource($this->handle) || $this->connections->establish($this);
+
+    $tries= 1;
+    retry: $result= ibase_query($sql, $this->handle);
     if (false === $result) {
       $message= 'Statement failed: '.trim(ibase_errmsg()).' @ '.$this->dsn->getHost();
       $code= ibase_errcode();
       switch ($code) {
         case -924:    // Connection lost
-          throw new \rdbms\SQLConnectionClosedException($message, $sql);
+          if (0 === $this->transaction && $this->connections->retry($this, $tries)) {
+            $tries++;
+            goto retry;
+          }
+          $this->close();
+          $this->transaction= 0;
+          throw new \rdbms\SQLConnectionClosedException($message, $tries, $sql, $code);
 
         case -913:    // Deadlock
           throw new \rdbms\SQLDeadlockException($message, $sql, $code);
@@ -162,6 +163,7 @@ class InterBaseConnection extends DBConnection {
   public function begin($transaction) {
     $this->query('begin transaction xp_%c', $transaction->name);
     $transaction->db= $this;
+    $this->transaction++;
     return $transaction;
   }
   
@@ -181,7 +183,8 @@ class InterBaseConnection extends DBConnection {
    * @param   string name
    * @return  bool success
    */
-  public function rollback($name) { 
+  public function rollback($name) {
+    $this->transaction--;
     return $this->query('rollback transaction xp_%c', $name);
   }
   
@@ -191,7 +194,8 @@ class InterBaseConnection extends DBConnection {
    * @param   string name
    * @return  bool success
    */
-  public function commit($name) { 
+  public function commit($name) {
+    $this->transaction--;
     return $this->query('commit transaction xp_%c', $name);
   }
 }

--- a/src/main/php/rdbms/mssql/MsSQLConnection.class.php
+++ b/src/main/php/rdbms/mssql/MsSQLConnection.class.php
@@ -207,8 +207,9 @@ class MsSQLConnection extends DBConnection {
    * @return  bool success
    */
   public function rollback($name) {
+    $this->query('rollback transaction xp_%c', $name);
     $this->transaction--;
-    return $this->query('rollback transaction xp_%c', $name);
+    return true;
   }
   
   /**
@@ -218,7 +219,8 @@ class MsSQLConnection extends DBConnection {
    * @return  bool success
    */
   public function commit($name) {
+    $this->query('commit transaction xp_%c', $name);
     $this->transaction--;
-    return $this->query('commit transaction xp_%c', $name);
+    return true;
   }
 }

--- a/src/main/php/rdbms/mysql/MySQLConnection.class.php
+++ b/src/main/php/rdbms/mysql/MySQLConnection.class.php
@@ -222,7 +222,7 @@ class MySQLConnection extends DBConnection {
    * @return  rdbms.Transaction
    */
   public function begin($transaction) {
-    if (!$this->query('begin')) return false;
+    $this->query('begin');
     $transaction->db= $this;
     $this->transaction++;
     return $transaction;
@@ -235,8 +235,9 @@ class MySQLConnection extends DBConnection {
    * @return  bool success
    */
   public function rollback($name) {
+    $this->query('rollback');
     $this->transaction--;
-    return $this->query('rollback');
+    return true;
   }
   
   /**
@@ -246,7 +247,8 @@ class MySQLConnection extends DBConnection {
    * @return  bool success
    */
   public function commit($name) {
+    $this->query('commit');
     $this->transaction--;
-    return $this->query('commit');
+    return true;
   }
 }

--- a/src/main/php/rdbms/mysql/MySQLConnection.class.php
+++ b/src/main/php/rdbms/mysql/MySQLConnection.class.php
@@ -1,9 +1,9 @@
 <?php namespace rdbms\mysql;
 
 use rdbms\DBConnection;
-use rdbms\Transaction;
-use rdbms\StatementFormatter;
 use rdbms\QuerySucceeded;
+use rdbms\StatementFormatter;
+use rdbms\Transaction;
 
 /**
  * Connection to MySQL Databases via ext/mysql
@@ -179,15 +179,10 @@ class MySQLConnection extends DBConnection {
    * @throws  rdbms.SQLException
    */
   protected function query0($sql, $buffered= true) {
-    if (!is_resource($this->handle)) {
-      if (!($this->flags & DB_AUTOCONNECT)) throw new \rdbms\SQLStateException('Not connected');
-      $c= $this->connect();
-      
-      // Check for subsequent connection errors
-      if (false === $c) throw new \rdbms\SQLStateException('Previously failed to connect.');
-    }
-    
-    if (!$buffered || $this->flags & DB_UNBUFFERED) {
+    is_resource($this->handle) || $this->connections->establish($this);
+
+    $tries= 1;
+    retry: if (!$buffered || $this->flags & DB_UNBUFFERED) {
       $result= @mysql_unbuffered_query($sql, $this->handle);
     } else {
       $result= @mysql_query($sql, $this->handle);
@@ -199,7 +194,13 @@ class MySQLConnection extends DBConnection {
       switch ($code) {
         case 2006: // MySQL server has gone away
         case 2013: // Lost connection to MySQL server during query
-          throw new \rdbms\SQLConnectionClosedException('Statement failed: '.$message, $sql, $code);
+          if (0 === $this->transaction && $this->connections->retry($this, $tries)) {
+            $tries++;
+            goto retry;
+          }
+          $this->close();
+          $this->transaction= 0;
+          throw new \rdbms\SQLConnectionClosedException($message, $tries, $sql, $code);
 
         case 1213: // Deadlock
           throw new \rdbms\SQLDeadlockException($message, $sql, $code);
@@ -223,6 +224,7 @@ class MySQLConnection extends DBConnection {
   public function begin($transaction) {
     if (!$this->query('begin')) return false;
     $transaction->db= $this;
+    $this->transaction++;
     return $transaction;
   }
   
@@ -232,7 +234,8 @@ class MySQLConnection extends DBConnection {
    * @param   string name
    * @return  bool success
    */
-  public function rollback($name) { 
+  public function rollback($name) {
+    $this->transaction--;
     return $this->query('rollback');
   }
   
@@ -242,7 +245,8 @@ class MySQLConnection extends DBConnection {
    * @param   string name
    * @return  bool success
    */
-  public function commit($name) { 
+  public function commit($name) {
+    $this->transaction--;
     return $this->query('commit');
   }
 }

--- a/src/main/php/rdbms/mysqli/MySQLiConnection.class.php
+++ b/src/main/php/rdbms/mysqli/MySQLiConnection.class.php
@@ -198,14 +198,19 @@ class MySQLiConnection extends DBConnection {
           }
           $this->close();
           $this->transaction= 0;
-          throw new \rdbms\SQLConnectionClosedException($message, $tries, $sql, $code);
+          $e= new \rdbms\SQLConnectionClosedException($message, $tries, $sql, $code);
+          break;
 
         case 1213: // Deadlock
-          throw new \rdbms\SQLDeadlockException($message, $sql, $code);
+          $e= new \rdbms\SQLDeadlockException($message, $sql, $code);
+          break;
         
         default:
-          throw new \rdbms\SQLStatementFailedException($message, $sql, $code);
+          $e= new \rdbms\SQLStatementFailedException($message, $sql, $code);
+          break;
       }
+      \xp::gc(__FILE__);
+      throw $e;
     } else if (true === $r) {
       return new QuerySucceeded(mysqli_affected_rows($this->handle));
     } else if ($buffered) {

--- a/src/main/php/rdbms/mysqli/MySQLiConnection.class.php
+++ b/src/main/php/rdbms/mysqli/MySQLiConnection.class.php
@@ -193,6 +193,7 @@ class MySQLiConnection extends DBConnection {
         case 2006: // MySQL server has gone away
         case 2013: // Lost connection to MySQL server during query
           if (0 === $this->transaction && $this->connections->retry($this, $tries)) {
+            \xp::gc(__FILE__);
             $tries++;
             goto retry;
           }

--- a/src/main/php/rdbms/mysqli/MySQLiConnection.class.php
+++ b/src/main/php/rdbms/mysqli/MySQLiConnection.class.php
@@ -229,7 +229,7 @@ class MySQLiConnection extends DBConnection {
    * @return  rdbms.Transaction
    */
   public function begin($transaction) {
-    if (!$this->query('begin')) return false;
+    $this->query('begin');
     $transaction->db= $this;
     $this->transaction++;
     return $transaction;
@@ -242,8 +242,9 @@ class MySQLiConnection extends DBConnection {
    * @return  bool success
    */
   public function rollback($name) {
+    $this->query('rollback');
     $this->transaction--;
-    return $this->query('rollback');
+    return true;
   }
   
   /**
@@ -253,8 +254,9 @@ class MySQLiConnection extends DBConnection {
    * @return  bool success
    */
   public function commit($name) {
+    $this->query('commit');
     $this->transaction--;
-    return $this->query('commit');
+    return true;
   }
 
   /**

--- a/src/main/php/rdbms/mysqlx/MySqlxConnection.class.php
+++ b/src/main/php/rdbms/mysqlx/MySqlxConnection.class.php
@@ -230,8 +230,9 @@ class MySqlxConnection extends DBConnection {
    * @return  bool success
    */
   public function rollback($name) {
+    $this->query('rollback');
     $this->transaction--;
-    return $this->query('rollback');
+    return true;
   }
   
   /**
@@ -241,8 +242,9 @@ class MySqlxConnection extends DBConnection {
    * @return  bool success
    */
   public function commit($name) { 
+    $this->query('commit');
     $this->transaction--;
-    return $this->query('commit');
+    return true;
   }
 
   /**

--- a/src/main/php/rdbms/mysqlx/MySqlxConnection.class.php
+++ b/src/main/php/rdbms/mysqlx/MySqlxConnection.class.php
@@ -1,18 +1,18 @@
 <?php namespace rdbms\mysqlx;
 
-use lang\XPClass;
 use io\IOException;
+use lang\XPClass;
 use peer\Socket;
 use rdbms\DBConnection;
 use rdbms\DBEvent;
 use rdbms\DriverManager;
 use rdbms\QuerySucceeded;
-use rdbms\StatementFormatter;
 use rdbms\SQLConnectException;
-use rdbms\SQLStateException;
-use rdbms\SQLDeadlockException;
-use rdbms\SQLStatementFailedException;
 use rdbms\SQLConnectionClosedException;
+use rdbms\SQLDeadlockException;
+use rdbms\SQLStateException;
+use rdbms\SQLStatementFailedException;
+use rdbms\StatementFormatter;
 use rdbms\Transaction;
 use rdbms\mysql\MysqlDialect;
 
@@ -166,15 +166,10 @@ class MySqlxConnection extends DBConnection {
    * @throws  rdbms.SQLException
    */
   protected function query0($sql, $buffered= true) {
-    if (!$this->handle->connected) {
-      if (!($this->flags & DB_AUTOCONNECT)) throw new SQLStateException('Not connected');
-      $c= $this->connect();
-      
-      // Check for subsequent connection errors
-      if (false === $c) throw new SQLStateException('Previously failed to connect.');
-    }
-    
-    try {
+    $this->handle->connected || $this->connections->establish($this);
+
+    $tries= 1;
+    retry: try {
       $this->handle->ready() || $this->handle->cancel();
       $result= $this->handle->query($sql);
     } catch (MySqlxProtocolException $e) {
@@ -182,17 +177,24 @@ class MySqlxConnection extends DBConnection {
       switch ($e->error) {
         case 2006: // MySQL server has gone away
         case 2013: // Lost connection to MySQL server during query
-          throw new SQLConnectionClosedException('Statement failed: '.$message, $sql, $e->error);
+          if (0 === $this->transaction && $this->connections->retry($this, $tries)) {
+            $tries++;
+            goto retry;
+          }
+          $this->close();
+          $this->transaction= 0;
+          throw new SQLConnectionClosedException($message, $tries, $sql, $e->error);
 
         case 1213: // Deadlock
           throw new SQLDeadlockException($message, $sql, $e->error);
         
-        default:   // Other error
+        default:
           throw new SQLStatementFailedException($message, $sql, $e->error);
       }
     } catch (IOException $e) {
-      $this->handle->close();
-      throw new SQLConnectionClosedException($e->getMessage(), $sql, -1);
+      $this->close();
+      $this->transaction= 0;
+      throw new SQLConnectionClosedException($e->getMessage(), $tries, $sql, -1);
     }
     
     if (!is_array($result)) {
@@ -215,7 +217,8 @@ class MySqlxConnection extends DBConnection {
    * @return  rdbms.Transaction
    */
   public function begin($transaction) {
-    if (!$this->query('begin')) return false;
+    $this->query('begin');
+    $this->transaction++;
     $transaction->db= $this;
     return $transaction;
   }
@@ -226,7 +229,8 @@ class MySqlxConnection extends DBConnection {
    * @param   string name
    * @return  bool success
    */
-  public function rollback($name) { 
+  public function rollback($name) {
+    $this->transaction--;
     return $this->query('rollback');
   }
   
@@ -237,6 +241,7 @@ class MySqlxConnection extends DBConnection {
    * @return  bool success
    */
   public function commit($name) { 
+    $this->transaction--;
     return $this->query('commit');
   }
 

--- a/src/main/php/rdbms/pgsql/PostgreSQLConnection.class.php
+++ b/src/main/php/rdbms/pgsql/PostgreSQLConnection.class.php
@@ -209,8 +209,9 @@ class PostgreSQLConnection extends DBConnection {
    * @return  bool success
    */
   public function rollback($name) {
+    $this->query('rollback transaction');
     $this->transaction--;
-    return $this->query('rollback transaction');
+    return true;
   }
   
   /**
@@ -220,7 +221,8 @@ class PostgreSQLConnection extends DBConnection {
    * @return  bool success
    */
   public function commit($name) {
+    $this->query('commit transaction');
     $this->transaction--;
-    return $this->query('commit transaction');
+    return true;
   }
 }

--- a/src/main/php/rdbms/sqlite3/SQLite3Connection.class.php
+++ b/src/main/php/rdbms/sqlite3/SQLite3Connection.class.php
@@ -199,8 +199,9 @@ class SQLite3Connection extends DBConnection {
    * @return  bool success
    */
   public function rollback($name) { 
+    $this->query('rollback transaction xp_%c', $name);
     $this->transaction--;
-    return $this->query('rollback transaction xp_%c', $name);
+    return true;
   }
   
   /**
@@ -210,7 +211,8 @@ class SQLite3Connection extends DBConnection {
    * @return  bool success
    */
   public function commit($name) { 
+    $this->query('commit transaction xp_%c', $name);
     $this->transaction--;
-    return $this->query('commit transaction xp_%c', $name);
+    return true;
   }
 }

--- a/src/main/php/rdbms/sqlsrv/SqlSrvConnection.class.php
+++ b/src/main/php/rdbms/sqlsrv/SqlSrvConnection.class.php
@@ -212,8 +212,9 @@ class SqlSrvConnection extends DBConnection {
    * @return  bool success
    */
   public function rollback($name) {
+    $this->query('rollback transaction xp_%c', $name);
     $this->transaction--;
-    return $this->query('rollback transaction xp_%c', $name);
+    return true;
   }
   
   /**
@@ -223,7 +224,8 @@ class SqlSrvConnection extends DBConnection {
    * @return  bool success
    */
   public function commit($name) {
+    $this->query('commit transaction xp_%c', $name);
     $this->transaction--;
-    return $this->query('commit transaction xp_%c', $name);
+    return true;
   }
 }

--- a/src/main/php/rdbms/sqlsrv/SqlSrvConnection.class.php
+++ b/src/main/php/rdbms/sqlsrv/SqlSrvConnection.class.php
@@ -1,9 +1,9 @@
 <?php namespace rdbms\sqlsrv;
 
 use rdbms\DBConnection;
-use rdbms\Transaction;
-use rdbms\StatementFormatter;
 use rdbms\QuerySucceeded;
+use rdbms\StatementFormatter;
+use rdbms\Transaction;
 
 /**
  * Connection to SqlSrv databases using client libraries
@@ -136,13 +136,7 @@ class SqlSrvConnection extends DBConnection {
    * @throws  rdbms.SQLException
    */
   protected function query0($sql, $buffered= true) {
-    if (!is_resource($this->handle)) {
-      if (!($this->flags & DB_AUTOCONNECT)) throw new \rdbms\SQLStateException('Not connected');
-      $c= $this->connect();
-      
-      // Check for subsequent connection errors
-      if (false === $c) throw new \rdbms\SQLStateException('Previously failed to connect');
-    }
+    is_resource($this->handle) || $this->connections->establish($this);
 
     // Cancel pending result sets. TODO: Look into using MARS (Multiple
     // Active Result Sets) feature, but this was causing problems in other
@@ -151,7 +145,8 @@ class SqlSrvConnection extends DBConnection {
       sqlsrv_free_stmt($this->result);
     }
 
-    $this->result= sqlsrv_query($this->handle, $sql);
+    $tries= 1;
+    retry: $this->result= sqlsrv_query($this->handle, $sql);
     if (false === $this->result) {
       $message= 'Statement failed: '.$this->errors().' @ '.$this->dsn->getHost();
       if (!is_resource($error= sqlsrv_query($this->handle, 'select @@error'))) {
@@ -163,7 +158,13 @@ class SqlSrvConnection extends DBConnection {
         // SqlSrv:  Client message:  Read from SQL server failed. (severity 78)
         //
         // but that seems a bit errorprone. 
-        throw new \rdbms\SQLConnectionClosedException($message, $sql);
+        if (0 === $this->transaction && $this->connections->retry($this, $tries)) {
+          $tries++;
+          goto retry;
+        }
+        $this->close();
+        $this->transaction= 0;
+        throw new \rdbms\SQLConnectionClosedException($message, $tries, $sql);
       }
 
       $code= current(sqlsrv_fetch_array($error, SQLSRV_FETCH_NUMERIC));
@@ -190,6 +191,7 @@ class SqlSrvConnection extends DBConnection {
   public function begin($transaction) {
     $this->query('begin transaction xp_%c', $transaction->name);
     $transaction->db= $this;
+    $this->transaction++;
     return $transaction;
   }
   
@@ -209,7 +211,8 @@ class SqlSrvConnection extends DBConnection {
    * @param   string name
    * @return  bool success
    */
-  public function rollback($name) { 
+  public function rollback($name) {
+    $this->transaction--;
     return $this->query('rollback transaction xp_%c', $name);
   }
   
@@ -219,7 +222,8 @@ class SqlSrvConnection extends DBConnection {
    * @param   string name
    * @return  bool success
    */
-  public function commit($name) { 
+  public function commit($name) {
+    $this->transaction--;
     return $this->query('commit transaction xp_%c', $name);
   }
 }

--- a/src/main/php/rdbms/sybase/SybaseConnection.class.php
+++ b/src/main/php/rdbms/sybase/SybaseConnection.class.php
@@ -215,8 +215,9 @@ class SybaseConnection extends DBConnection {
    * @return  bool success
    */
   public function rollback($name) {
+    $this->query('rollback transaction xp_%c', $name);
     $this->transaction--;
-    return $this->query('rollback transaction xp_%c', $name);
+    return true;
   }
   
   /**
@@ -226,7 +227,8 @@ class SybaseConnection extends DBConnection {
    * @return  bool success
    */
   public function commit($name) {
+    $this->query('commit transaction xp_%c', $name);
     $this->transaction--;
-    return $this->query('commit transaction xp_%c', $name);
+    return true;
   }
 }

--- a/src/main/php/rdbms/tds/TdsConnection.class.php
+++ b/src/main/php/rdbms/tds/TdsConnection.class.php
@@ -1,16 +1,17 @@
 <?php namespace rdbms\tds;
 
-use peer\Socket;
 use io\IOException;
+use peer\Socket;
 use rdbms\DBConnection;
-use rdbms\QuerySucceeded;
-use rdbms\Transaction;
 use rdbms\DBEvent;
+use rdbms\QuerySucceeded;
 use rdbms\SQLConnectException;
+use rdbms\SQLConnectionClosedException;
+use rdbms\SQLDeadlockException;
 use rdbms\SQLStateException;
 use rdbms\SQLStatementFailedException;
-use rdbms\SQLDeadlockException;
 use rdbms\StatementFormatter;
+use rdbms\Transaction;
 use rdbms\mssql\MsSQLDialect;
 
 /**
@@ -65,7 +66,7 @@ abstract class TdsConnection extends DBConnection {
     try {
       $this->handle->connect($this->dsn->getUser(), $this->dsn->getPassword(), $this->dsn->getProperty('charset', null));
       $this->_obs && $this->notifyObservers(new DBEvent(DBEvent::CONNECTED, $reconnect));
-    } catch (\io\IOException $e) {
+    } catch (IOException $e) {
       $this->handle->connected= null;
       $this->_obs && $this->notifyObservers(new DBEvent(DBEvent::CONNECTED, $reconnect));
       $message= '';
@@ -134,15 +135,10 @@ abstract class TdsConnection extends DBConnection {
    * @throws  rdbms.SQLException
    */
   protected function query0($sql, $buffered= true) {
-    if (!$this->handle->connected) {
-      if (!($this->flags & DB_AUTOCONNECT)) throw new SQLStateException('Not connected');
-      $c= $this->connect();
-      
-      // Check for subsequent connection errors
-      if (false === $c) throw new SQLStateException('Previously failed to connect.');
-    }
-    
-    try {
+    $this->handle->connected || $this->connections->establish($this);
+
+    $tries= 1;
+    retry: try {
       $this->handle->ready() || $this->handle->cancel();
       $result= $this->handle->query($sql);
     } catch (TdsProtocolException $e) {
@@ -155,7 +151,13 @@ abstract class TdsConnection extends DBConnection {
           throw new SQLStatementFailedException($message, $sql, $e->number);
       }
     } catch (IOException $e) {
-      throw new SQLStatementFailedException($e->getMessage());
+      if (0 === $this->transaction && $this->connections->retry($this, $tries)) {
+        $tries++;
+        goto retry;
+      }
+      $this->close();
+      $this->transaction= 0;
+      throw new SQLConnectionClosedException($e->getMessage(), $tries, $sql);
     }
     
     if (!is_array($result)) {
@@ -180,6 +182,7 @@ abstract class TdsConnection extends DBConnection {
   public function begin($transaction) {
     $this->query('begin transaction xp_%c', $transaction->name);
     $transaction->db= $this;
+    $this->transaction++;
     return $transaction;
   }
 
@@ -189,7 +192,7 @@ abstract class TdsConnection extends DBConnection {
    * @param   string name
    * @return  var state
    */
-  public function transtate($name) { 
+  public function transtate($name) {
     return $this->query('select @@transtate as transtate')->next('transtate');
   }
   
@@ -199,7 +202,8 @@ abstract class TdsConnection extends DBConnection {
    * @param   string name
    * @return  bool success
    */
-  public function rollback($name) { 
+  public function rollback($name) {
+    $this->transaction--;
     return $this->query('rollback transaction xp_%c', $name);
   }
   
@@ -209,7 +213,8 @@ abstract class TdsConnection extends DBConnection {
    * @param   string name
    * @return  bool success
    */
-  public function commit($name) { 
+  public function commit($name) {
+    $this->transaction--;
     return $this->query('commit transaction xp_%c', $name);
   }
 

--- a/src/main/php/rdbms/tds/TdsConnection.class.php
+++ b/src/main/php/rdbms/tds/TdsConnection.class.php
@@ -203,8 +203,9 @@ abstract class TdsConnection extends DBConnection {
    * @return  bool success
    */
   public function rollback($name) {
+    $this->query('rollback transaction xp_%c', $name);
     $this->transaction--;
-    return $this->query('rollback transaction xp_%c', $name);
+    return true;
   }
   
   /**
@@ -214,8 +215,9 @@ abstract class TdsConnection extends DBConnection {
    * @return  bool success
    */
   public function commit($name) {
+    $this->query('commit transaction xp_%c', $name);
     $this->transaction--;
-    return $this->query('commit transaction xp_%c', $name);
+    return true;
   }
 
   /**

--- a/src/test/php/rdbms/unittest/DBTest.class.php
+++ b/src/test/php/rdbms/unittest/DBTest.class.php
@@ -87,7 +87,7 @@ class DBTest extends TestCase {
 
   #[@test, @expect(SQLStateException::class)]
   public function queryOnFailedConnection() {
-    $this->conn->connections->automatic(true);
+    $this->conn->connections->automatic(true)->reconnect(0);
 
     $this->conn->makeConnectFail('Access denied');
     try {

--- a/src/test/php/rdbms/unittest/DBTest.class.php
+++ b/src/test/php/rdbms/unittest/DBTest.class.php
@@ -1,13 +1,13 @@
 <?php namespace rdbms\unittest;
  
+use rdbms\DriverManager;
 use rdbms\ResultSet;
 use rdbms\SQLConnectException;
-use rdbms\SQLStateException;
 use rdbms\SQLConnectionClosedException;
+use rdbms\SQLStateException;
 use rdbms\SQLStatementFailedException;
-use rdbms\DriverManager;
-use unittest\TestCase;
 use rdbms\unittest\mock\MockResultSet;
+use unittest\TestCase;
 
 /**
  * Test rdbms API
@@ -87,6 +87,8 @@ class DBTest extends TestCase {
 
   #[@test, @expect(SQLStateException::class)]
   public function queryOnFailedConnection() {
+    $this->conn->connections->automatic(true);
+
     $this->conn->makeConnectFail('Access denied');
     try {
       $this->conn->connect();

--- a/src/test/php/rdbms/unittest/DBTest.class.php
+++ b/src/test/php/rdbms/unittest/DBTest.class.php
@@ -79,10 +79,22 @@ class DBTest extends TestCase {
 
   #[@test, @expect(SQLConnectionClosedException::class)]
   public function connectionLost() {
+    $this->conn->connections->automatic(true)->reconnect(0);
+
     $this->conn->connect();
     $this->assertQuery();
     $this->conn->letServerDisconnect();
     $this->conn->query('select 1');   // Not connected
+  }
+
+  #[@test]
+  public function connection_reestablished() {
+    $this->conn->connections->automatic(true)->reconnect(1);
+
+    $this->conn->connect();
+    $this->assertQuery();
+    $this->conn->letServerDisconnect();
+    $this->assertQuery();
   }
 
   #[@test, @expect(SQLStateException::class)]

--- a/src/test/php/rdbms/unittest/integration/MySQLIntegrationTest.class.php
+++ b/src/test/php/rdbms/unittest/integration/MySQLIntegrationTest.class.php
@@ -1,12 +1,9 @@
 <?php namespace rdbms\unittest\integration;
 
+use rdbms\SQLConnectionClosedException;
 use rdbms\SQLException;
+use rdbms\Transaction;
 
-/**
- * MySQL integration test
- *
- * @ext       mysql
- */
 class MySQLIntegrationTest extends RdbmsIntegrationTest {
 
   /** @return string */
@@ -27,7 +24,8 @@ class MySQLIntegrationTest extends RdbmsIntegrationTest {
   /**
    * Create autoincrement table
    *
-   * @param   string name
+   * @param  string $name
+   * @return void
    */
   protected function createAutoIncrementTable($name) {
     $this->removeTable($name);
@@ -37,7 +35,8 @@ class MySQLIntegrationTest extends RdbmsIntegrationTest {
   /**
    * Create transactions table
    *
-   * @param   string name
+   * @param  string $name
+   * @return void
    */
   protected function createTransactionsTable($name) {
     $this->removeTable($name);
@@ -258,5 +257,25 @@ class MySQLIntegrationTest extends RdbmsIntegrationTest {
 
     $after= $conn->query('select connection_id() as id')->next('id');
     $this->assertNotEquals($before, $after, 'Connection IDs must be different');
+  }
+
+  #[@test]
+  public function does_not_reconnect_if_disconnected_inside_transaction() {
+    $conn= $this->db();
+    $before= $conn->query('select connection_id() as id')->next('id');
+
+    $tran= $conn->begin(new Transaction('test'));
+    try {
+      $conn->query('kill %d', $before);
+    } catch (SQLException $expected) {
+      // errorcode 1927: Connection was killed (sqlstate 70100)
+    }
+
+    try {
+      $conn->query('select connection_id() as id');
+      $this->fail('No exception raised', null, SQLConnectionClosedException::class);
+    } catch (SQLConnectionClosedException $expected) {
+      // errorcode 2006: Server disconnected (sqlstate 00000)
+    }
   }
 }

--- a/src/test/php/rdbms/unittest/integration/RdbmsIntegrationTest.class.php
+++ b/src/test/php/rdbms/unittest/integration/RdbmsIntegrationTest.class.php
@@ -1,20 +1,20 @@
 <?php namespace rdbms\unittest\integration;
 
-use util\Date;
-use rdbms\ResultSet;
-use rdbms\DSN;
-use rdbms\DBEvent;
-use rdbms\SQLStateException;
-use rdbms\SQLConnectException;
-use rdbms\SQLStatementFailedException;
-use rdbms\SQLException;
-use util\Observer;
-use unittest\TestCase;
-use unittest\PrerequisitesNotMetError;
-use rdbms\DriverManager;
-use util\Bytes;
-use lang\Throwable;
 use lang\MethodNotImplementedException;
+use lang\Throwable;
+use rdbms\DBEvent;
+use rdbms\DSN;
+use rdbms\DriverManager;
+use rdbms\ResultSet;
+use rdbms\SQLConnectException;
+use rdbms\SQLException;
+use rdbms\SQLStateException;
+use rdbms\SQLStatementFailedException;
+use unittest\PrerequisitesNotMetError;
+use unittest\TestCase;
+use util\Bytes;
+use util\Date;
+use util\Observer;
 
 /**
  * Base class for all RDBMS integration tests
@@ -124,7 +124,7 @@ abstract class RdbmsIntegrationTest extends TestCase {
 
   #[@test, @expect(SQLStateException::class)]
   public function noQueryWhenNotConnected() {
-    $this->conn->flags ^= DB_AUTOCONNECT;
+    $this->conn->connections->automatic(false);
     $this->conn->query('select 1');
   }
   
@@ -144,7 +144,7 @@ abstract class RdbmsIntegrationTest extends TestCase {
 
   #[@test, @expect(SQLStateException::class)]
   public function noQueryWhenDisConnected() {
-    $this->conn->flags ^= DB_AUTOCONNECT;
+    $this->conn->connections->automatic(false);
     $this->conn->connect();
     $this->conn->close();
     $this->conn->query('select 1');

--- a/src/test/php/rdbms/unittest/mock/MockConnection.class.php
+++ b/src/test/php/rdbms/unittest/mock/MockConnection.class.php
@@ -1,7 +1,7 @@
 <?php namespace rdbms\unittest\mock;
 
-use rdbms\Transaction;
 use rdbms\StatementFormatter;
+use rdbms\Transaction;
 
 /**
  * Mock database connection.
@@ -226,13 +226,7 @@ class MockConnection extends \rdbms\DBConnection {
    * @throws  rdbms.SQLException
    */
   protected function query0($sql, $buffered= true) { 
-    if (!$this->_connected) {
-      if (!($this->flags & DB_AUTOCONNECT)) throw new \rdbms\SQLStateException('Not connected');
-      $c= $this->connect();
-      
-      // Check for subsequent connection errors
-      if (false === $c) throw new \rdbms\SQLStateException('Previously failed to connect.');
-    }
+    $this->_connected || $this->connections->establish($this);
     
     $this->sql= $sql;
 

--- a/src/test/php/rdbms/unittest/mock/MockConnection.class.php
+++ b/src/test/php/rdbms/unittest/mock/MockConnection.class.php
@@ -20,7 +20,7 @@ class MockConnection extends \rdbms\DBConnection {
     $sql              = null;
 
   public
-    $_connected       = false;
+    $_connected       = null;
 
   /**
    * Constructor
@@ -164,8 +164,8 @@ class MockConnection extends \rdbms\DBConnection {
   public function connect($reconnect= false) {
     $this->sql= null;
   
-    if ($this->_connected && !$reconnect) return true;
-    
+    if (!$reconnect && null !== $this->_connected) return $this->_connected;
+
     $this->_obs && $this->notifyObservers(new \rdbms\DBEvent(\rdbms\DBEvent::CONNECT, $reconnect));
     if ($this->connectError) {
       $this->_connected= false;
@@ -183,7 +183,7 @@ class MockConnection extends \rdbms\DBConnection {
    * @return  bool success
    */
   public function close() {
-    $this->_connected= false;
+    $this->_connected= null;
     return true;
   }
 


### PR DESCRIPTION
## In a nutshell

This pull request extracts connection handling from the driver classes to the new `rdbms.Connections` class, which implements:

* The previous "autoconnect" semantics which establish a connection with the database when a query is issued
* A new mode that will reconnect and rerun queries when receiving a "connection closed" error from the database

## DSN

Both behaviors can be controlled through the connection DSN. The default values are:

```
driver://user:pass@host/?autoconnect=1&reconnect=1
```

...meaning autoconnect semantics are set to *true*, and reconnections are attempted once (*except inside transactions, of course*).

## See also

Supersedes #42 - see [this comment](https://github.com/xp-framework/rdbms/pull/42#issuecomment-392255408)
See also xp-framework/rfc#315