### PR TITLE
Default reconnect to 1

### DIFF
--- a/src/main/php/rdbms/DBConnection.class.php
+++ b/src/main/php/rdbms/DBConnection.class.php
@@ -61,7 +61,7 @@ abstract class DBConnection extends Observable {
 
     $this->connections= new Connections(
       $this->flags & DB_AUTOCONNECT,
-      $this->dsn->getProperty('reconnect', 0)
+      $this->dsn->getProperty('reconnect', 1)
     );
   }
 

--- a/src/test/php/rdbms/unittest/integration/MySQLIntegrationTest.class.php
+++ b/src/test/php/rdbms/unittest/integration/MySQLIntegrationTest.class.php
@@ -247,7 +247,6 @@ class MySQLIntegrationTest extends RdbmsIntegrationTest {
   #[@test]
   public function reconnects_when_server_disconnects() {
     $conn= $this->db();
-    $conn->connections->reconnect(1);
     $before= $conn->query('select connection_id() as id')->next('id');
 
     try {
@@ -263,7 +262,6 @@ class MySQLIntegrationTest extends RdbmsIntegrationTest {
   #[@test]
   public function does_not_reconnect_if_disconnected_inside_transaction() {
     $conn= $this->db();
-    $conn->connections->reconnect(1);
     $before= $conn->query('select connection_id() as id')->next('id');
 
     $tran= $conn->begin(new Transaction('test'));


### PR DESCRIPTION
This pull request changes the `reconnect` default value to **1**. This was introduced in PR #44 but set to **0** for backwards compatibility. 

**⚠️ This pull request will bump the major version => 11.0.0**