### PR TITLE
Remove unused affectedRows() method

### DIFF
--- a/src/main/php/rdbms/DBConnection.class.php
+++ b/src/main/php/rdbms/DBConnection.class.php
@@ -179,13 +179,6 @@ abstract class DBConnection extends Observable {
   }
   
   /**
-   * Retrieve number of affected rows
-   *
-   * @return  int
-   */
-  protected function affectedRows() {}
-  
-  /**
    * Execute an insert statement
    *
    * @param  string $statement

--- a/src/main/php/rdbms/ibase/InterBaseConnection.class.php
+++ b/src/main/php/rdbms/ibase/InterBaseConnection.class.php
@@ -107,15 +107,6 @@ class InterBaseConnection extends DBConnection {
   }
 
   /**
-   * Retrieve number of affected rows for last query
-   *
-   * @return  int
-   */
-  protected function affectedRows() {
-    return ibase_affected_rows($this->handle);
-  }
-  
-  /**
    * Execute any statement
    *
    * @param   string sql

--- a/src/main/php/rdbms/mssql/MsSQLConnection.class.php
+++ b/src/main/php/rdbms/mssql/MsSQLConnection.class.php
@@ -121,15 +121,6 @@ class MsSQLConnection extends DBConnection {
   }
 
   /**
-   * Retrieve number of affected rows for last query
-   *
-   * @return  int
-   */
-  protected function affectedRows() {
-    return mssql_rows_affected($this->handle);
-  }
-  
-  /**
    * Execute any statement
    *
    * @param   string sql

--- a/src/main/php/rdbms/mysql/MySQLConnection.class.php
+++ b/src/main/php/rdbms/mysql/MySQLConnection.class.php
@@ -160,15 +160,6 @@ class MySQLConnection extends DBConnection {
     $this->_obs && $this->notifyObservers(new \rdbms\DBEvent(\rdbms\DBEvent::IDENTITY, $i));
     return $i;
   }
-
-  /**
-   * Retrieve number of affected rows for last query
-   *
-   * @return  int
-   */
-  protected function affectedRows() {
-    return mysql_affected_rows($this->handle);
-  }    
   
   /**
    * Execute any statement

--- a/src/main/php/rdbms/mysqli/MySQLiConnection.class.php
+++ b/src/main/php/rdbms/mysqli/MySQLiConnection.class.php
@@ -156,15 +156,6 @@ class MySQLiConnection extends DBConnection {
   }
 
   /**
-   * Retrieve number of affected rows for last query
-   *
-   * @return  int
-   */
-  protected function affectedRows() {
-    return mysqli_affected_rows($this->handle);
-  }    
-  
-  /**
    * Execute any statement
    *
    * @param   string sql

--- a/src/main/php/rdbms/mysqlx/MySqlxConnection.class.php
+++ b/src/main/php/rdbms/mysqlx/MySqlxConnection.class.php
@@ -24,7 +24,6 @@ use rdbms\mysql\MysqlDialect;
  * @test  xp://net.xp_framework.unittest.rdbms.DBTest
  */
 class MySqlxConnection extends DBConnection {
-  protected $affected= -1;
 
   static function __static() {
     DriverManager::register('mysql+x', new XPClass(__CLASS__));
@@ -149,15 +148,6 @@ class MySqlxConnection extends DBConnection {
   }
 
   /**
-   * Retrieve number of affected rows for last query
-   *
-   * @return  int
-   */
-  protected function affectedRows() {
-    return $this->affected;
-  }    
-  
-  /**
    * Execute any statement
    *
    * @param   string sql
@@ -198,11 +188,9 @@ class MySqlxConnection extends DBConnection {
     }
     
     if (!is_array($result)) {
-      $this->affected= $result;
       return new QuerySucceeded($result);
     }
 
-    $this->affected= -1;
     if (!$buffered || $this->flags & DB_UNBUFFERED) {
       return new MySqlxResultSet($this->handle, $result, $this->tz);
     } else {

--- a/src/main/php/rdbms/pgsql/PostgreSQLConnection.class.php
+++ b/src/main/php/rdbms/pgsql/PostgreSQLConnection.class.php
@@ -114,15 +114,6 @@ class PostgreSQLConnection extends DBConnection {
   }
 
   /**
-   * Retrieve number of affected rows for last query
-   *
-   * @return  int
-   */
-  protected function affectedRows() { 
-    return pg_affected_rows($this->result);
-  }
-  
-  /**
    * Execute any statement
    *
    * @param   string sql

--- a/src/main/php/rdbms/sqlite3/SQLite3Connection.class.php
+++ b/src/main/php/rdbms/sqlite3/SQLite3Connection.class.php
@@ -144,15 +144,6 @@ class SQLite3Connection extends DBConnection {
   }
 
   /**
-   * Retrieve number of affected rows
-   *
-   * @return  int
-   */
-  protected function affectedRows() {
-    return $this->handle->changes();
-  }
-  
-  /**
    * Execute any statement
    *
    * @param   string sql

--- a/src/main/php/rdbms/sqlsrv/SqlSrvConnection.class.php
+++ b/src/main/php/rdbms/sqlsrv/SqlSrvConnection.class.php
@@ -119,15 +119,6 @@ class SqlSrvConnection extends DBConnection {
   }
 
   /**
-   * Retrieve number of affected rows for last query
-   *
-   * @return  int
-   */
-  protected function affectedRows() {
-    return sqlsrv_rows_affected($this->result);
-  }
-  
-  /**
    * Execute any statement
    *
    * @param   string sql

--- a/src/main/php/rdbms/sybase/SybaseConnection.class.php
+++ b/src/main/php/rdbms/sybase/SybaseConnection.class.php
@@ -122,15 +122,6 @@ class SybaseConnection extends DBConnection {
   }
 
   /**
-   * Retrieve number of affected rows for last query
-   *
-   * @return  int
-   */
-  protected function affectedRows() {
-    return sybase_affected_rows($this->handle);
-  }
-  
-  /**
    * Execute any statement
    *
    * @param   string sql

--- a/src/main/php/rdbms/tds/TdsConnection.class.php
+++ b/src/main/php/rdbms/tds/TdsConnection.class.php
@@ -21,7 +21,6 @@ use rdbms\mssql\MsSQLDialect;
  * @test  xp://net.xp_framework.unittest.rdbms.DBTest
  */
 abstract class TdsConnection extends DBConnection {
-  protected $affected= -1;
 
   /**
    * Constructor
@@ -118,15 +117,6 @@ abstract class TdsConnection extends DBConnection {
   }
 
   /**
-   * Retrieve number of affected rows for last query
-   *
-   * @return  int
-   */
-  protected function affectedRows() {
-    return $this->affected;
-  }    
-  
-  /**
    * Execute any statement
    *
    * @param   string sql
@@ -161,11 +151,9 @@ abstract class TdsConnection extends DBConnection {
     }
     
     if (!is_array($result)) {
-      $this->affected= $result;
       return new QuerySucceeded($result);
     }
 
-    $this->affected= -1;
     if (!$buffered || $this->flags & DB_UNBUFFERED) {
       return new TdsResultSet($this->handle, $result, $this->tz);
     } else {

--- a/src/test/php/rdbms/unittest/mock/MockConnection.class.php
+++ b/src/test/php/rdbms/unittest/mock/MockConnection.class.php
@@ -214,15 +214,6 @@ class MockConnection extends DBConnection {
   }
 
   /**
-   * Retrieve number of affected rows for last query
-   *
-   * @return  int
-   */
-  protected function affectedRows() {
-    return $this->affectedRows;
-  }    
-  
-  /**
    * Execute any statement
    *
    * @param   string sql


### PR DESCRIPTION
This became obsolete when the `QuerySuceeded` class was introduced in #16