### PR TITLE
Add support for util.UUID instances

### DIFF
--- a/src/main/php/rdbms/StatementFormatter.class.php
+++ b/src/main/php/rdbms/StatementFormatter.class.php
@@ -128,6 +128,9 @@ class StatementFormatter {
         $type= 's';
         $this->conn->tz && $arg= $this->conn->tz->translate($arg);
         $p= $arg->toString($this->dialect->dateFormat);
+      } else if ($arg instanceof \util\UUID) {
+        $type= 's';
+        $p= $arg->hashCode();
       } else if ($arg instanceof SQLRenderable) {
         $r.= $arg->asSql($this->conn).', ';
         continue;

--- a/src/test/php/rdbms/unittest/TokenizerTest.class.php
+++ b/src/test/php/rdbms/unittest/TokenizerTest.class.php
@@ -3,7 +3,7 @@
 use rdbms\{DBConnection, SQLStateException};
 use unittest\actions\RuntimeVersion;
 use unittest\{Expect, Test};
-use util\Date;
+use util\{Date, UUID};
 
 /**
  * Test rdbms tokenizer
@@ -162,6 +162,15 @@ abstract class TokenizerTest extends \unittest\TestCase {
     $this->assertEquals(
       "select * from news where date= '1977-12-14 00:00:00'",
       $this->fixture->prepare('select * from news where date= %s', $t)
+    );
+  }
+
+  #[Test]
+  public function uuidToken() {
+    $t= new UUID('b1e2f772-ae5b-4eba-aca5-174c8d0f4cc1');
+    $this->assertEquals(
+      "select * from news where id= 'b1e2f772-ae5b-4eba-aca5-174c8d0f4cc1'",
+      $this->fixture->prepare('select * from news where id= %s', $t)
     );
   }
 


### PR DESCRIPTION
## Why
UUIDs work better than auto-increment integer numbers in cluster settings and with very large datasets. They also reduce the security risks of being able to easily guess the next ID, and of being able to determine service usage numbers. See e.g. https://qvault.io/clean-code/what-are-uuids-and-should-you-use-them/

## What

* [x] Transparent support in tokenizer - use `%s` and pass *UUID* instances
* [ ] Support when reading

## Support

* https://dev.mysql.com/blog-archive/mysql-8-0-uuid-support/
* https://mariadb.com/kb/en/uuid-data-type/
* https://docs.microsoft.com/en-us/sql/t-sql/data-types/uniqueidentifier-transact-sql?view=sql-server-ver15
* https://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.help.sqlanywhere.12.0.1/mlserver/uuids-ml-synchtech.html
* https://www.postgresql.org/docs/9.1/datatype-uuid.html
* https://sqlite.org/src/file/ext/misc/uuid.c